### PR TITLE
Reworked german locale

### DIFF
--- a/customLocale/de_DE/lib/pkp/locale/de_DE/admin.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/admin.po
@@ -1,0 +1,3 @@
+
+msgid "admin.scheduledTask.publishSubmissions"
+msgstr "Die zur Veröffentlichung vorgesehenen Konferenzbeiträge jetzt veröffentlichen"

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/api.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/api.po
@@ -1,0 +1,18 @@
+
+msgid "api.publicFiles.500.badFilesDir"
+msgstr "Das Verzeichnis für öffentliche Dokumente wurde nicht gefunden oder Dateien können nicht dorthin gespeichert werden. Bitte wenden Sie sich zur Problemlösung an Ihre/n Administrator/in."
+
+msgid "api.submissionFiles.400.badDependentFileAssocType"
+msgstr "Sie können eine Datei aus dieser Einreichungsstufe nicht mit einer anderen Einreichungsdatei für Konferenzbeiträge verknüpfen."
+
+msgid "api.submissionFiles.400.reviewRoundSubmissionNotMatch"
+msgstr "Die von Ihnen bereitgestllte Begutachtungsrunde ist nicht Teil dieser Einreichung für den Konferenzband."
+
+msgid "api.submissions.403.deleteSubmissionOutOfContext"
+msgstr "Sie können keine Einreichung für einen Konferenzbeitrag löschen die nicht diesem Kontext zugeordnet ist."
+
+msgid "api.submissions.403.requestedOthersUnpublishedSubmissions"
+msgstr "Sie können nur die Ihnen zugeordneten unveröffentlichte Konferenzbeiträge einsehen."
+
+msgid "api.submissions.403.unauthorizedDeleteSubmission"
+msgstr "Sie sind nicht berechtigt, diese Einreichung für die Konferenz zu löschen."

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/common.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/common.po
@@ -1,0 +1,15 @@
+
+msgid "navigation.submissions"
+msgstr "Konferenzbeitrageinreichungen"
+
+msgid "notification.removedSubmission"
+msgstr "Konferenzbeitragseinreichung entfernt"
+
+msgid "notification.savedSubmissionMetadata"
+msgstr "Metadaten für Konferenzbeitragseinreichung gespeichert."
+
+msgid "search.cli.rebuildIndex.result"
+msgstr "{$numIndexed} Konferenzbeitragseinreichungen indexiert."
+
+msgid "user.authorization.invalidSubmission"
+msgstr "Ungültige Konferenzbeitragseinreichung."

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/editor.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/editor.po
@@ -1,0 +1,18 @@
+
+msgid "editor.submissionArchive.confirmDelete"
+msgstr "Sind Sie sicher, dass Sie diese Konferenzbeitragseinreichung endgültig löschen möchten?"
+
+msgid "editor.submission.workflowDecision.submission.declined"
+msgstr "Konferenzbeitragseinreichung abgelehnt."
+
+msgid "editor.submission.workflowDecision.submission.accepted"
+msgstr "Konferenzbeitragseinreichung akzeptiert."
+
+msgid "editor.submission.workflowDecision.submission.published"
+msgstr "Konferenzbeitragseinreichung veröffentlicht"
+
+msgid "editor.submission.workflowDecision.submission.underReview"
+msgstr "Konferenzbeitragseinreichung zum Review zugelassen."
+
+msgid "reviewer.list.currentlyAssigned"
+msgstr "Dieser Gutachter wurde bereits mit der Begutachtung dieser Konferenzbeitragseinreichung beauftragt."

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/grid.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/grid.po
@@ -1,0 +1,36 @@
+
+msgid "grid.action.requestRevisions"
+msgstr "Überarbeitung für diese Konferenzbeitragseinreichung anfordern"
+
+msgid "grid.action.accept"
+msgstr "Diese Konferenzbeitragseinreichung annehmen"
+
+msgid "grid.action.decline"
+msgstr "Konferenzbeitragseinreichung ablehnen"
+
+msgid "grid.action.internalReview"
+msgstr "Konferenzbeitragseinreichung in die internen Begutachtung schicken"
+
+msgid "grid.action.externalReview"
+msgstr "Konferenzbeitragseinreichung in die externe Begutachtung schicken"
+
+msgid "grid.action.sendToProduction"
+msgstr "Konferenzbeitragseinreichung in die Produktion schicken"
+
+msgid "grid.action.viewMetadata"
+msgstr "Die Metadaten zu dieser Konferenzbeitragseinreichung ansehen"
+
+msgid "grid.action.bookInfo"
+msgstr "Informationen zur Konferenzbeitragseinreichung"
+
+msgid "grid.libraryFiles.submission.title"
+msgstr "Konferenzbeitragseinreichungsbibliothek"
+
+msgid "grid.submissionChecklist.title"
+msgstr "Checkliste für Konferenzbeitragseinreichungen"
+
+msgid "grid.artworkFile.placement"
+msgstr "Platzierung in der Konferenzbeitragseinreichung"
+
+msgid "grid.submission.active.selectOrphaned"
+msgstr "Inklusive unfertiger Konferenzbeitragseinreichungen, die nicht durch eine/n Autor/in eingereicht wurden."

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/manager.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/manager.po
@@ -1,0 +1,236 @@
+
+msgid "manager.genres.alertDelete"
+msgstr "Bevor diese Komponente gelöscht werden kann, müssen alle zugehörigen Konferenzbeitragseinreichungen einer anderen Komponente zugewiesen werden."
+
+msgid "manager.publication.submissionStage"
+msgstr "Konferenzbeitragseinreichung"
+
+msgid "manager.language.submissions"
+msgstr "Konferenzbeitragseinreichungen"
+
+msgid "manager.representative.inUse"
+msgstr "Sie können diesen Vertreter nicht löschen. Er ist den market Metadaten eines oder mehrerer Puklikationsformate  des Konferenzbandes zugeordnet."
+
+msgid "manager.statistics.reports.description"
+msgstr "Das System erstellt Berichte, die die Details der Verarbeitung von Konferenzbeiträgen aus der Perspektive von Beiträgen, Redakteur/innen, Gutachter/innen sowie Rubriken über einen festgelegten Zeitraum nachzeichnen. Die Berichte werden im CSV-Format erstellt, die mit einer Tabellenkalkulation betrachtet werden können."
+
+msgid "manager.setup.copyrightNotice.description"
+msgstr "Autor/innen müssen im Konferenzbeitragseinreichungsverfahren der Lizenz zustimmen."
+
+msgid "manager.setup.authorGuidelines.description"
+msgstr "Für die Richtlinien werden Standards für Bibliografie und Format sowie Beispiele für gängige Zitierformate, die in Konferenbeitragseinreichungen benutzt werden sollen, vorgeschlagen."
+
+msgid "manager.setup.disableSubmissions"
+msgstr "Einreichung von Konferenzbeiträgen deaktivieren"
+
+msgid "manager.setup.notifications"
+msgstr "Bestätigung der Konferenzbeitragseinreichung durch die Autor/innen"
+
+msgid "manager.setup.notifications.description"
+msgstr "Autor/innen erhalten automatisch eine E-Mail, die ihnen den Eingang ihrer Konferenzbeitragseinreichung bestätigt. Darüber hinaus können Kopien der Bestätigungs-E-Mail an die folgenden Adressen verschickt werden:"
+
+msgid "manager.setup.peerReview.description"
+msgstr "Beschreiben Sie die Begutachtungsrichtlinien und die Abläufe für Leser/innen und Autor/innen. Diese Beschreibung enthält üblicherweise die Anzahl der Gutachter/innen, die typischerweise eine Konferenzbeitragseinreichung begutachten, die Kriterien, anhand derer Gutachter/innen urteilen sollen, die erwartete Begutachtungsdauer und die Grundsätze der Gutachter/innenauswahl."
+
+
+msgid "manager.setup.privacyStatement.description"
+msgstr "Diese Erklärung wird während der Registrierung neuer Nutzer/innen, bei Autor/innenkonferenzbeitragseinreichungen und auf der öffentlichen Seite zum Datenschutz angezeigt. In manchen Staaten sind Sie rechtlich verpflichtet, in dieser Erklärung anzugeben, wie Sie mit den Daten der Nutzer/innen verfahren."
+
+msgid "manager.sections.form.deactivateSection"
+msgstr "Diese Sektion deaktivieren und keine neuen Konferenzbeitragseinreichungen zu dieser Sektion zulassen."
+
+msgid "settings.roles.permitMetadataEdit"
+msgstr "Änderung der Metadaten dieser Konferezbeitragseinreichung erlauben."
+
+msgid "manager.setup.metadata.submission"
+msgstr "Konferenzbeitragseinreichungs-Formular"
+
+msgid "manager.setup.metadata.coverage.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Metadaten zur Abdeckung von Autor/in erfragen."
+
+msgid "manager.setup.metadata.coverage.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zur Abdeckung bitten."
+
+msgid "manager.setup.metadata.coverage.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zur Abdeckung von Autor/in verlangen."
+
+msgid "manager.setup.metadata.keywords.description"
+msgstr "Schlagworte sind typischerweise ein bis drei Worte lange Phrasen, die auf das Fachgebiet der Konferenzbeitragseinreichung hinweisen."
+
+msgid "manager.setup.metadata.keywords.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Schlagworte von Autor/in erfragen."
+
+msgid "manager.setup.metadata.keywords.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zu Schlagworten bitten."
+
+msgid "manager.setup.metadata.keywords.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zu Schlagworten von Autor/in verlangen."
+
+msgid "manager.setup.metadata.languages.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Angabe zur Sprache von Autor/in erfragen."
+
+msgid "manager.setup.metadata.languages.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zur Sprache von Autor/in verlangen."
+
+msgid "manager.setup.metadata.rights.description"
+msgstr "Alle Rechte an diesem Konferenzbeitrag einschließlich Schutz- und Urheberrechten sowie Eigentumsrechten"
+
+msgid "manager.setup.metadata.rights.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Angaben zu Rechten von Autor/in erfragen."
+
+msgid "manager.setup.metadata.rights.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zur Rechten bitten."
+
+msgid "manager.setup.metadata.rights.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zu Rechten von Autor/in verlangen."
+
+msgid "manager.setup.metadata.source.description"
+msgstr "Die Quelle kann eine ID wie z.B. eine DOI eines anderen Werkes sein, welches Grundlage der vorliegenden Konferenzbeitragseinreichung war."
+
+msgid "manager.setup.metadata.source.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Quellen-URL von Autor/in erfragen."
+
+msgid "manager.setup.metadata.source.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Quellen-URL bitten."
+
+msgid "manager.setup.metadata.source.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zur Quellen-URL von Autor/in verlangen."
+
+msgid "manager.setup.metadata.subjects.description"
+msgstr "Themen sind Stichworte, Stichwortketten oder Klassifizierungscodes, die das Fachgebiet einer Konferenzbeitragseinreichung beschreiben."
+
+msgid "manager.setup.metadata.subjects.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Angaben zu Themen von Autor/in erfragen."
+
+msgid "manager.setup.metadata.subjects.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zum Thema bitten."
+
+msgid "manager.setup.metadata.subjects.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zu Themen von Autor/in verlangen."
+
+msgid "manager.setup.metadata.type.description"
+msgstr "Art oder Genre vom Hauptteil der Konferenzbeitragseinreichung. Der Typ ist normalerweise \"Text\", kann aber auch \"Datensatz\", \"Bild\" oder jedem anderen der <a target=\"_blank\" href=\"http://dublincore.org/documents/dcmi-type-vocabulary/#section-7-dcmi-type-vocabulary\">Dublin Core Typen</a> entsprechen."
+
+msgid "manager.setup.metadata.type.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Angaben zum Typ von Autor/in erfragen."
+
+msgid "manager.setup.metadata.type.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zum Typ bitten."
+
+msgid "manager.setup.metadata.type.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zum Typ von Autor/in verlangen."
+
+msgid "manager.setup.metadata.disciplines.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Angabe zu Disziplinen von Autor/in erfragen."
+
+msgid "manager.setup.metadata.disciplines.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zu Disziplinen bitten."
+
+msgid "manager.setup.metadata.disciplines.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zu Disziplinen von Autor/in verlangen."
+
+msgid "manager.setup.metadata.agencies.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine unterstützenden Organistationen von Autor/in erfragen."
+
+msgid "manager.setup.metadata.agencies.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zu unterstützenden Organistationen bitten."
+
+msgid "manager.setup.metadata.agencies.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zu unterstützenden Organistationen von Autor/in verlangen."
+
+msgid "manager.setup.metadata.citations.description"
+msgstr "Die Referenzen einer Konferenzbeitragseinreichung in einem separaten Feld sammeln. Dies könnte erforderlich sein, um Erfordernissen von Services zu Zitationszählungen wie Crossref zu entsprechen."
+
+msgid "manager.setup.metadata.citations.noRequest"
+msgstr "Bei der Konferenzbeitragseinreichung keine Referenzen von Autor/in erfragen."
+
+msgid "manager.setup.metadata.citations.request"
+msgstr "Autor/in bei der Konferenzbeitragseinreichung um Angaben zu Referenzen bitten."
+
+msgid "manager.setup.metadata.citations.require"
+msgstr "Vor Annahme der Konferenzbeitragseinreichung Angaben zu Referenzen von Autor/in verlangen."
+
+msgid "plugins.importexport.common.error.missingGivenName"
+msgstr "Autor/in {$authorName} hat keinen Vornamen in der in der Konferenzbeitragseinreichung verwendeten Sprache, {$localeName}. Die Konferenzbeitragseinreichung kann nicht importiert werden ohne diese Information."
+
+msgid "plugins.importexport.common.error.duplicateRevisionForSubmission"
+msgstr "Die Überarbeitung \"{$revisionId}\" für die Konferenzbeitragseinreichungsdatei \"{$fileId}\" würde einen doppelten Eintrag anlegen"
+
+msgid "plugins.importexport.native.error.submissionFileImportFailed"
+msgstr "Die Konferenzbeitragseinreichungsdatei konnte nicht importiert werden"
+
+msgid "plugins.importexport.native.error.submissionFileSkipped"
+msgstr "Die Konferenzbeitragseinreichungsdatei {$id} wurde übersprungen, weil sie an einen Datensatz angehängt ist, der nicht importiert wird, z. B. eine Begutachtung oder eine Diskussion."
+
+msgid "plugins.importexport.native.error.submissionFileWithoutRevision"
+msgstr "Die Konferenzbeitragseinreichungsdatei {$id} wurde übersprungen, da sie keine gültige Überarbeitung hat."
+
+msgid "plugins.importexport.native.error.submissionFileRevisionMissing"
+msgstr "Die Überarbeitung {$revision} der Konferenzbeitragseinreichungsdatei {$id} wurde übersprungen, da die Datei nicht unter dem Pfad \"{$path}\" gefunden wurde."
+
+msgid "manager.navigationMenus.form.submenuWarning"
+msgstr "Falls ein Menüeintrag ein Untermenü öffnet, kann der Link nicht mit allen Geräten genutzt werden. Beispielsweise, falls Sie ein \"Über uns\" Eintrag haben mit einem Untermenü \"Kontakt\" und \"Redaktion\", können nicht unbedingt alle Geräte den \"Über uns\" Link aufrufen. Im Standardmenü wird dies dadurch behoben, dass ein zweiter Menüeintrag \"Über die Konferenzbandreihe\" erstellt wird, welcher im Untermenü erscheint."
+
+msgid "manager.navigationMenus.about.description"
+msgstr "Dieser Link wird nur angezeigt, falls Sie den Abschnitt Über uns in den Einstellungen  > Konferenzbandreihe ausgefüllt haben."
+
+msgid "manager.navigationMenus.about.conditionalWarning"
+msgstr "Dieser Link wird nur angezeigt, falls Sie den Abschnitt Über uns in den Einstellungen > Konferenzbandreihe ausgefüllt haben."
+
+msgid "manager.navigationMenus.editorialTeam.description"
+msgstr "Link zur Seite, welche den Inhalt des Impressums aus den Einstellungen > Konferenzbandreihe anzeigt."
+
+msgid "manager.navigationMenus.editorialTeam.conditionalWarning"
+msgstr "This link will only be displayed if you have filled out the Editorial Team section under Settings > Conference Proceedings Series."
+
+msgid "manager.navigationMenus.submissions.description"
+msgstr "Link to the page displaying Conference Proceedings  Submission instructions."
+
+msgid "manager.navigationMenus.current.description"
+msgstr "Link to your current Conference Proceedings Volume."
+
+msgid "manager.navigationMenus.archives.description"
+msgstr "Link to your Conference Proceedings Volume archive."
+
+msgid "manager.navigationMenus.privacyStatement.conditionalWarning"
+msgstr "This link will only be displayed if you have entered a privacy statement under Settings > Workflow > Conference Proceedings  Submissions."
+
+msgid "stats.description.acceptRejectRate"
+msgstr "Der Anteil für den gewählten Datumsbereich wird berechnet auf Grundlage der Konferenzbeitragseinreichungen, die innerhalb dieses Datumsbereichs eingereicht wurden und für die eine endgültige Entscheidung getroffen wurde.<br><br> Gingen zum Beispiel zehn Konferenzbeitragseinreichungen innerhalb des Datumsbereichs ein, von denen vier angenommen wurden, vier abgelehnt wurden und zwei noch unentschieden sind, so liegt die Annahmerate bei 50% (vier von acht Konferenzbeitragseinreichungen), denn über zwei Konferenzbeitragseinreichungen wurde noch nicht abschließend entschieden."
+
+msgid "stats.description.daysToDecision"
+msgstr "Die Anzahl der Tage, bis eine erste redaktionelle Entscheidung für eine Konferenzbeitragseinreichung getroffen wird, wie zum Beispiel direkte Ablehnung oder Versenden zum Review.<br><br> Diese Zahlen zeigen, dass für 80% aller Konferenzbeitragseinreichungen eine Entscheidung innerhalb der angegebenen Anzahl von Tagen getroffen wird.<br><br> Diese Statistik versucht anzugeben, wann die Mehrheit der Autoren dieser Konferenzbandreihe eine Entscheidung erwarten können."
+
+msgid "stats.description.submissionsSkipped"
+msgstr "Dies beinhaltet Konferenzbeitragseinreichungen, die nicht in anderen Gesamtzahlen gezählt werden, z.B. solche, die noch bearbeitet werden oder solche, die importiert wurden."
+
+msgid "stats.submissionsActive"
+msgstr "Aktive Konferenzbeitragseinreichungen"
+
+msgid "stats.name.submissionsReceived"
+msgstr "Erhaltene Konferenzbeitragseinreichungen"
+
+msgid "stats.name.submissionsSkipped"
+msgstr "Andere Konferenzbeitragseinreichungen"
+
+msgid "stats.name.submissionsInProgress"
+msgstr "Laufende Konferenzbeitragseinreichungen"
+
+msgid "stats.name.submissionsImported"
+msgstr "Importierte Konferenzbeitragseinreichungen"
+
+msgid "stats.name.submissionsAccepted"
+msgstr "Angenommene Konferenzbeitragseinreichungen"
+
+msgid "stats.name.submissionsDeclined"
+msgstr "Abgelehnte Konferenzbeitragseinreichungen"
+
+msgid "stats.name.submissionsDeclinedDeskReject"
+msgstr "Abgelehnte Konferenzbeitragseinreichungen (direkt ohne Peer Review, desk rejection)"
+
+msgid "stats.name.submissionsDeclinedPostReview"
+msgstr "Abgelehnte Konferenzbeitragseinreichungen (nach Peer Review)"
+
+msgid "stats.name.submissionsPublished"
+msgstr "Veröffentlichte Konferenzbeitragseinreichungen"
+

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/reviewer.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/reviewer.po
@@ -1,0 +1,7 @@
+
+msgid "reviewer.step1.viewAllDetails"
+msgstr "Alle Details der Konferenzbeitragseinreichung ansehen"
+
+msgid "reviewer.submission.reviewDescription"
+msgstr "Geben Sie ihr Gutachten für die Konferenzbeitragseinreichung in das untenstehende Formular ein."
+

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/submission.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/submission.po
@@ -1,48 +1,48 @@
 
 msgid "submission.submit.contactConsentDescription"
-msgstr "Yes, I would like to be contacted about this Conference Proceedings  Submission."
+msgstr "Ja, ich würde gerne bezüglich dieser Konferenzbeitragseinreichung kontaktiert werden."
 
 msgid "submission.submit.submissionChecklist"
-msgstr "Conference Proceedings Submission Requirements"
+msgstr "Konferenzbeitragseinreichungs-Anforderungen"
 
 msgid "submission.submit.submissionComplete"
-msgstr "Conference Proceedings Submission complete"
+msgstr "Die Konferenzbeitragseinreichung ist abgeschlossen"
 
 msgid "submission.submit.whatNext.review"
-msgstr "Review this Conference Proceedings  Submission"
+msgstr "Die Konferenzbeitragseinreichung begutachten"
 
 msgid "submission.submit.whatNext.create"
-msgstr "Create a new Conference Proceedings  Submission"
+msgstr "Eine neue Konferenzbeitragseinreichung erstellen"
 
 msgid "metadata.property.displayName.article-title"
-msgstr "Conference Proceedings Submission/Paper Title"
+msgstr "Konferenzbeitrags/Paper-Titel"
 
 msgid "metadata.property.validationMessage.article-title"
-msgstr "Please enter a valid Conference Proceedings Submission/paper title."
+msgstr "Bitte geben Sie einen gültigen Konferenzbeitrags/Paper-Titel ein."
 
 msgid "metadata.property.displayName.issue"
-msgstr "Conference Proceedings Volume"
+msgstr "Konferenzbeitragsausgabe"
 
 msgid "metadata.property.validationMessage.issue"
-msgstr "Please enter a valid Conference Proceedings Volume."
+msgstr "Bitte geben Sie eine gültige Ausgabe ein."
 
 msgid "common.queue.long.submissionsArchived"
-msgstr "Archived Conference Proceedings  Submissions"
+msgstr "Archivierte Konferenzbeiträge"
 
 msgid "submission.backToSubmissionEditing"
-msgstr "Back to Conference Proceedings Submission Editing"
+msgstr "Zurück zur Konferenzbeitragsbearbeitung"
 
 msgid "submission.email.confirmClearLog"
-msgstr "Are you sure you want to clear the email log for this Conference Proceedings  Submission?"
+msgstr "Sind Sie sicher, dass Sie das E-Mail-Protokoll zu diesem Konferenzbeitrag löschen wollen?"
 
 msgid "submission.event.confirmClearLog"
-msgstr "Are you sure you want to clear the event log for this Conference Proceedings  Submission?"
+msgstr "Sind Sie sicher, dass Sie das Ereignisprotokoll zu diesem Konferenzbeitrag löschen wollen?"
 
 msgid "submission.event.submissionSubmitted"
-msgstr "Initial Conference Proceedings  Submission completed."
+msgstr "Erst-Konferenzbeitragseinreichung abgeschlossen."
 
 msgid "submission.event.fileRevised"
-msgstr "Revision \"{$name}\" was uploaded for file {$submissionFileId}."
+msgstr "Revision \"{$name}\" was uploaded for file {$Conference Proceedings  SubmissionFileId}."
 
 msgid "submission.event.general.metadataUpdated"
 msgstr "Conference Proceedings Submission metadata updated"

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/user.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/user.po
@@ -1,0 +1,13 @@
+
+msgid "user.login.registrationComplete.manageSubmissions"
+msgstr "Zeige Konferenzbeitragseinreichungen"
+
+msgid "user.login.registrationComplete.newSubmission"
+msgstr "Neuen Konferenzbeitrag einreichen"
+
+msgid "user.profile.form.openAccessNotifications"
+msgstr "E-Mail-Benachrichtigung: Freien Zugang zu Konferenzband Ausgaben"
+
+msgid "user.profile.form.publishedNotifications"
+msgstr "E-Mail-Benachrichtigung: neue Konferenzband Ausgaben erschienen"
+

--- a/locale/de_DE/locale.po
+++ b/locale/de_DE/locale.po
@@ -15,4 +15,25 @@ msgid "plugins.generic.conference.metadata.conferenceDateBegin.title"
 msgstr "Konferenz Metadaten"
 
 msgid "plugins.generic.conference.metadata.conferenceDateBegin"
-msgstr "<![CDATA[Konferenz DOI von <a href=\"https://projects.tib.eu/confident/\><https://projects.tib.eu/confident/>]"
+msgstr "Startdatum"
+
+msgid "plugins.generic.conference.metadata.conferenceDateEnd"
+msgstr "Enddatum"
+
+msgid "plugins.generic.conference.metadata.conferencePlace.title"
+msgstr "Ort der Konferenz"
+
+msgid "plugins.generic.conference.metadata.conferencePlaceStreet"
+msgstr "Straße / Platz"
+
+msgid "plugins.generic.conference.metadata.conferencePlaceCity"
+msgstr "Stadt"
+
+msgid "plugins.generic.conference.metadata.conferencePlaceCountry"
+msgstr "Land"
+
+msgid "plugins.generic.conference.displayName"
+msgstr "Konferenzveröffentlichung"
+
+msgid "plugins.generic.conference.description"
+msgstr "Ermöglicht Konferenzen in OJS abzubilden. Konferenzspezifische Metadaten werden nach aktivierung automatisch hinzugefügt und das Frontend und Backend wird angepasst um Konferenzveröffentlichungen darzustellen."


### PR DESCRIPTION
Now the updated PR, I included German locale in order to enable the plugin within German instances of OJS. 
Further, I fixes a bug within "`en_US/lib/pkp/locale/en_US/submission.po`":
` "Revision \"{$name}\" was uploaded for file {$Conference Proceedings  SubmissionFileId}."` >> `msgstr "Revision \"{$name}\" was uploaded for file {$submissionFileId}."`
