### PR TITLE
 Übersetzung für de_DE und Anpassung fehlerhafte Variablenreferenzen in en_US

### DIFF
--- a/customLocale/de_DE/lib/pkp/locale/de_DE/admin.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/admin.po
@@ -1,3 +1,4 @@
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "admin.scheduledTask.publishSubmissions"
 msgstr "Die zur Veröffentlichung vorgesehenen Konferenzbeiträge jetzt veröffentlichen"

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/api.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/api.po
@@ -1,3 +1,6 @@
+# Pia Piontkowitz <pia.piontkowitz@rub.de>, 2022, 2023.
+# Heike Riegler <heike.riegler@julius-kuehn.de>, 2022.
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "api.publicFiles.500.badFilesDir"
 msgstr "Das Verzeichnis für öffentliche Dokumente wurde nicht gefunden oder Dateien können nicht dorthin gespeichert werden. Bitte wenden Sie sich zur Problemlösung an Ihre/n Administrator/in."

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/common.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/common.po
@@ -1,6 +1,9 @@
+# Pia Piontkowitz <pia.piontkowitz@rub.de>, 2021, 2022, 2023.
+# Heike Riegler <heike.riegler@julius-kuehn.de>, 2022.
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "navigation.submissions"
-msgstr "Konferenzbeitrageinreichungen"
+msgstr "Konferenzbeitragseinreichungen"
 
 msgid "notification.removedSubmission"
 msgstr "Konferenzbeitragseinreichung entfernt"

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/editor.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/editor.po
@@ -1,3 +1,6 @@
+# Pia Piontkowitz <pia.piontkowitz@rub.de>, 2021, 2023.
+# Heike Riegler <heike.riegler@julius-kuehn.de>, 2022.
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "editor.submissionArchive.confirmDelete"
 msgstr "Sind Sie sicher, dass Sie diese Konferenzbeitragseinreichung endgültig löschen möchten?"

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/grid.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/grid.po
@@ -1,3 +1,6 @@
+# Heike Riegler <heike.riegler@julius-kuehn.de>, 2022.
+# Pia Piontkowitz <pia.piontkowitz@rub.de>, 2022, 2023.
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "grid.action.requestRevisions"
 msgstr "Überarbeitung für diese Konferenzbeitragseinreichung anfordern"

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/manager.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/manager.po
@@ -1,3 +1,8 @@
+# Sebastian Wolf <bibliothekswelt@htmlwolf.de>, 2021.
+# Pia Piontkowitz <pia.piontkowitz@rub.de>, 2021, 2022, 2023.
+# Heike Riegler <heike.riegler@julius-kuehn.de>, 2022.
+# Martin Brändle <martin.braendle@uzh.ch>, 2023.
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "manager.genres.alertDelete"
 msgstr "Bevor diese Komponente gelöscht werden kann, müssen alle zugehörigen Konferenzbeitragseinreichungen einer anderen Komponente zugewiesen werden."

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/reviewer.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/reviewer.po
@@ -1,3 +1,5 @@
+# Sebastian Wolf <bibliothekswelt@htmlwolf.de>, 2021
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "reviewer.step1.viewAllDetails"
 msgstr "Alle Details der Konferenzbeitragseinreichung ansehen"

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/submission.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/submission.po
@@ -1,3 +1,7 @@
+# Sebastian Wolf <bibliothekswelt@htmlwolf.de>, 2021.
+# Pia Piontkowitz <pia.piontkowitz@rub.de>, 2021, 2023.
+# Martin Brändle <martin.braendle@uzh.ch>, 2022.
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "submission.submit.contactConsentDescription"
 msgstr "Ja, ich würde gerne bezüglich dieser Konferenzbeitragseinreichung kontaktiert werden."
@@ -42,142 +46,142 @@ msgid "submission.event.submissionSubmitted"
 msgstr "Erst-Konferenzbeitragseinreichung abgeschlossen."
 
 msgid "submission.event.fileRevised"
-msgstr "Revision \"{$name}\" was uploaded for file {$Conference Proceedings  SubmissionFileId}."
+msgstr "Die Revision \"{$filename}\" für Datei {$submissionFileId} wurde hochgeladen."
 
 msgid "submission.event.general.metadataUpdated"
-msgstr "Conference Proceedings Submission metadata updated"
+msgstr "Metadaten des Konferenzbeitrags aktualisiert"
 
 msgid "submission.event.general.suppFileUpdated"
-msgstr "Conference Proceedings Submission file updated"
+msgstr "Konferenzbeitrags-Anlagedatei aktualisiert"
 
 msgid "submission.event.reviewer.reviewerAssigned"
-msgstr "Reviewer assigned to Conference Proceedings  Submission"
+msgstr "Konferenzbeitragseinreichung einer Gutachterin/einem Gutachter zugewiesen"
 
 msgid "submission.event.reviewer.reviewerUnassigned"
-msgstr "Reviewer unassigned from Conference Proceedings  Submission"
+msgstr "Gutachter/in nicht länger für die Konferenzbeitragseinreichung zuständig"
 
 msgid "submission.history.submissionNotes"
-msgstr "Conference Proceedings Submission Notes"
+msgstr "Einträge zu den Konferenzbeitragseinreichungen"
 
 msgid "submission.informationCenter.submissionInfo"
-msgstr "Conference Proceedings Submission Info"
+msgstr "Informationen zur Konferenzbeitragseinreichung"
 
 msgid "submission.layout.viewingGalley"
-msgstr "Viewing Conference Proceedings Submission Galley"
+msgstr "Konferenzbeitragsfahne anzeigen"
 
 msgid "submission.metadata"
-msgstr "Conference Proceedings Submission Metadata"
+msgstr "Metadaten der Konferenzbeitragseinreichung"
 
 msgid "submission.notes.backToSubmissionNotes"
-msgstr "Back To Conference Proceedings Submission Notes"
+msgstr "Zurück zu den Anmerkungen zur Konferenzbeitragseinreichung"
 
 msgid "submission.notes.confirmDeleteAll"
-msgstr "Remove All Conference Proceedings Submission Notes?"
+msgstr "Wollen Sie alle Anmerkungen zu dieser Konferenzbeitragseinreichung löschen?"
 
 msgid "submission.notes.confirmDelete"
-msgstr "Remove This Conference Proceedings Submission Note?"
+msgstr "Wollen Sie die Anmerkung zu dieser Konferenzbeitragseinreichung löschen?"
 
 msgid "submission.notes.noSubmissionNotes"
-msgstr "No Conference Proceedings Submission Notes"
+msgstr "Keine Anmerkungen zur Konferenzbeitragseinreichung"
 
 msgid "submission.notes"
-msgstr "Conference Proceedings Submission Notes"
+msgstr "Anmerkungen zur Konferenzbeitragseinreichung"
 
 msgid "submissions.noSubmissions"
-msgstr "No Conference Proceedings  Submissions"
+msgstr "Keine Konferenzbeitragseinreichungen"
 
 msgid "submissions.queuedUnassigned"
-msgstr "No editor has been assigned to this Conference Proceedings  Submission."
+msgstr "Diese Konferenzbeitragseinreichung wurde noch kein/e Redakteur/in zugewiesen."
 
 msgid "submission.submission"
-msgstr "Conference Proceedings Submission"
+msgstr "Konferenzbeitragseinreichung"
 
 msgid "submission.submissionTitle"
-msgstr "Conference Proceedings Submission Title:"
+msgstr "Konferenzbeitragstitel:"
 
 msgid "submission.submissionHistory"
-msgstr "Conference Proceedings Submission History"
+msgstr "Verlauf der Bearbeitung der Konferenzbeitragseinreichung"
 
 msgid "submission.submissionManuscript"
-msgstr "Conference Proceedings Submission Manuscript"
+msgstr "Konferenzbeitragsmanuskript"
 
 msgid "submission.submissionReview"
-msgstr "Conference Proceedings Submission Review"
+msgstr "Begutachtung des Konferenzbeitrags"
 
 msgid "submission.submit.finishSubmission"
-msgstr "Finish Conference Proceedings Submission"
+msgstr "Schließe Konferenzbeitragseinreichung ab"
 
 msgid "submission.submit.submissionLocale"
-msgstr "Conference Proceedings Submission Language"
+msgstr "Sprache der Konferenzbeitragseinreichung"
 
 msgid "submission.submit.submissionFiles"
-msgstr "Conference Proceedings Submission Files"
+msgstr "Konferenzbeitragseinreichung-Dateien"
 
 msgid "submission.submit.uploadSubmissionFile"
-msgstr "Upload Conference Proceedings Submission File"
+msgstr "Lade Konferenzbeitragseinreichungs-Datei hoch"
 
 msgid "submission.upload.libraryCategory"
-msgstr "Conference Proceedings Submission Document Category"
+msgstr "Dokumentkategorie der Konferenzbeitragseinreichung"
 
 msgid "editor.submission.roundStatus.resubmitForReview"
-msgstr "The Conference Proceedings  Submission must be resubmitted for another review round."
+msgstr "Die Konferenzbeitragseinreichung muss wieder eingereicht werden für eine neue Begutachtungsrunde."
 
 msgid "editor.submission.roundStatus.submissionResubmitted"
-msgstr "Conference Proceedings Submission has been resubmitted for another review round."
+msgstr "Die Konferenzbeitragseinreichung wurde wieder eingereicht für eine neue Begutachtungsrunde."
 
 msgid "editor.submission.roundStatus.accepted"
-msgstr "Conference Proceedings Submission accepted."
+msgstr "Konferenzbeitrag akzeptiert."
 
 msgid "editor.submission.roundStatus.declined"
-msgstr "Conference Proceedings Submission declined."
+msgstr "Konferenzbeitrag abgelehnt."
 
 msgid "editor.submission.decision.accept"
-msgstr "Accept Conference Proceedings Submission"
+msgstr "Konferenzbeitragseinreichung annehmen"
 
 msgid "editor.submission.decision.decline"
-msgstr "Decline Conference Proceedings Submission"
+msgstr "Konferenzbeitrag ablehnen"
 
 msgid "editor.submission.recommendation.description"
-msgstr "Recommend an editorial decision for this Conference Proceedings  Submission."
+msgstr "Eine redaktionelle Entscheidung für diese Konferenzbeitragseinreichung empfehlen."
 
 msgid "submission.overview"
-msgstr "Conference Proceedings Submission Overview"
+msgstr "Überblick über die Konferenzbeitragseinreichung"
 
 msgid "submission.documents"
-msgstr "Conference Proceedings Submission Documents"
+msgstr "Dokumente der Konferenzbeitragseinreichung"
 
 msgid "notification.type.editorAssign"
-msgstr "You have been assigned as an editor to the Conference Proceedings  Submission \"{$title}\"."
+msgstr "Sie sind als Redakteur/in für den Konferenzbeitrag \"{$title}\" eingeteilt worden."
 
 msgid "notification.type.editorDecisionAccept"
-msgstr "Conference Proceedings Submission accepted."
+msgstr "Konferenzbeitragseinreichung akzeptiert."
 
 msgid "notification.type.editorDecisionDecline"
-msgstr "Conference Proceedings Submission declined."
+msgstr "Konferenzbeitragseinreichung abgelehnt."
 
 msgid "notification.type.editorDecisionRevertDecline"
-msgstr "Declined Conference Proceedings  Submission reactivated."
+msgstr "Abgelehnte Konferenzbeitragseinreichung reaktiviert."
 
 msgid "notification.type.submissionNewVersion"
-msgstr "A new version of a Conference Proceedings  Submission was created"
+msgstr "Eine neue Version einer Konferenzbeitragseinreichung wurde erstellt"
 
 msgid "notification.type.revertDecline"
-msgstr "The decision to decline this Conference Proceedings  Submission was reverted."
+msgstr "Die Entscheidung diese Konferenzbeitragseinreichung abzulehnen wurde revidiert."
 
 msgid "grid.action.itemWorkflow"
-msgstr "Go to this Conference Proceedings  Submission's workflow"
+msgstr "Zum Workflow für diese Konferenzbeitragseinreichung gehen"
 
 msgid "submission.attachPermissions"
-msgstr "Attach the following permissions to the Conference Proceedings  Submission:"
+msgstr "Die folgenden Rechte für die Konferenzbeitragseinreichung festlegen:"
 
 msgid "submission.list.empty"
-msgstr "No Conference Proceedings  Submissions found."
+msgstr "Keine Konferenzbeitragseinreichungen gefunden."
 
 msgid "submission.list.confirmDelete"
-msgstr "Delete Conference Proceedings  Submission?"
+msgstr "Konferenzbeitragseinreichung löschen?"
 
 msgid "submission.list.viewSubmission"
-msgstr "View Conference Proceedings Submission"
+msgstr "Konferenzbeitragseinreichung ansehen"
 
 msgid "submission.list.incompleteSubmissionNotice"
-msgstr "This Conference Proceedings  Submission must be completed before an editor will review it."
+msgstr "Diese Konferenzbeitragseinreichung muss vervollständigt werden, bevor sie durch eine/n Redakteur/in begutachtet wird."

--- a/customLocale/de_DE/lib/pkp/locale/de_DE/user.po
+++ b/customLocale/de_DE/lib/pkp/locale/de_DE/user.po
@@ -1,3 +1,7 @@
+# Sebastian Wolf <bibliothekswelt@htmlwolf.de>, 2021.
+# Pia Piontkowitz <pia.piontkowitz@rub.de>, 2021, 2023.
+# Heike Riegler <heike.riegler@julius-kuehn.de>, 2022.
+# Sebastian Schmidt <sebastian.schmidt@slub-dresden.de>, 2023
 
 msgid "user.login.registrationComplete.manageSubmissions"
 msgstr "Zeige Konferenzbeitragseinreichungen"

--- a/customLocale/de_DE/locale/de_DE/admin.po
+++ b/customLocale/de_DE/locale/de_DE/admin.po
@@ -1,0 +1,33 @@
+msgid "admin.hostedContexts"
+msgstr "Konferenzbände auf dieser Website"
+
+msgid "admin.settings.redirect"
+msgstr "Umleitung zu dem Konferenzband"
+
+msgid "admin.journals.journalSettings"
+msgstr "Konferenzbände-Einstellungen"
+
+msgid "admin.journals.noneCreated"
+msgstr "Es wurde keine Konferenzband eingerichtet."
+
+msgid "admin.contexts.create"
+msgstr "Einen Konferenzband einrichten"
+
+msgid "admin.contexts.form.pathExists"
+msgstr "Der gewählte Zugangspfad wird bereits für einen anderen Konferenzband verwendet."
+
+msgid "admin.contexts.form.primaryLocaleNotSupported"
+msgstr "Die primäre Regionaleinstellung muss aus einer Regionaleinstellung der Konferenzband ausgewählt werden."
+
+msgid "admin.journals.enableJournalInstructions"
+msgstr "Einstellen, dass dieser Konferenzband öffentlich auf der Website auftaucht"
+
+msgid "admin.contexts.contextDescription"
+msgstr "Beschreibung des Konferenzbandes"
+
+msgid "admin.journal.pathImportInstructions"
+msgstr "Existierender oder einzurichtender Zugangspfad zum Konferenzband (z.B. \ojs\)."
+
+msgid "admin.journals.transcode"
+msgstr "Metadaten des Konferenzbeitrags aus ISO 8859-1 umkodieren"
+

--- a/customLocale/de_DE/locale/de_DE/api.po
+++ b/customLocale/de_DE/locale/de_DE/api.po
@@ -1,0 +1,36 @@
+msgid "api.announcements.400.contextsNotMatched"
+msgstr "Die angefragte Mitteilung ist nicht Teil dieser Konferenzband."
+
+msgid "api.emails.403.disabled"
+msgstr "Die E-Mail-Benachrichtigungsfunktion wurde für dieses Journal nicht aktiviert."
+
+msgid "api.submissions.403.cantChangeContext"
+msgstr "Sie können die Konferenzband einer Konferenzbeitragseinreichung nicht ändern."
+
+msgid "api.submissions.403.unpublishedIssues"
+msgstr "Sie haben keine Berechtigung, unveröffentlichte Ausgaben zu sehen."
+
+msgid "api.contexts.403.requestedDisabledContexts"
+msgstr "Sie können nur Konferenzbände ansehen die freigeschaltet sind."
+
+msgid "api.contexts.403.notAllowed"
+msgstr "Sie haben keine Berechtigung diesen Konferenzband anzusehen."
+
+msgid "api.contexts.403.requiresContext"
+msgstr "Sie können diese Konferenzband nicht von der site-wide API aus ändern."
+
+msgid "api.contexts.403.notAllowedEdit"
+msgstr "Sie haben keine Berechtigung diese Konferenzband zu ändern."
+
+msgid "api.contexts.403.notAllowedDelete"
+msgstr "Sie haben keine Berechtigung diese Konferenzband zu löschen."
+
+msgid "api.contexts.404.contextNotFound"
+msgstr "Der Konferenzband, nach dem Sie suchen, wurde nicht gefunden."
+
+msgid "api.publications.403.contextsDidNotMatch"
+msgstr "Der Beitrag, den Sie suchen, ist nicht Teil dieses Konferenzband."
+
+msgid "api.publications.403.submissionsDidNotMatch"
+msgstr "Die Publikation, den Sie suchen, ist nicht Teil dieser Konferenzbandeinreichung."
+

--- a/customLocale/de_DE/locale/de_DE/author.po
+++ b/customLocale/de_DE/locale/de_DE/author.po
@@ -1,0 +1,111 @@
+msgid "author.submit"
+msgstr "Neuer Beitrag"
+
+msgid "author.track"
+msgstr "Konferenzbeiträge im Begutachtungsverfahren"
+
+msgid "author.submit.submitArticle"
+msgstr "Einen Konferenzbeitrag einreichen"
+
+msgid "author.submit.startHereTitle"
+msgstr "Beginnen Sie eine neue Konferenzbeitragseinreichung"
+
+msgid "author.submit.startHereLink"
+msgstr "<a href=\{$submitUrl}\ class=\action\>Hier anklicken</a>, um zu Schritt 1 des Konferenzbeitragseinreichungsverfahrens zu gelangen."
+
+msgid "author.submit.step1"
+msgstr "Schritt 1. Konferenzbeitragseinreichung beginnen"
+
+msgid "author.submit.step2"
+msgstr "Schritt 2. Konferenzbeitrag hochladen"
+
+msgid "author.submit.step3"
+msgstr "Schritt 3. Metadaten des Konferenzbeitrages eingeben"
+
+msgid "author.submit.step5"
+msgstr "Schritt 5. Konferenzbeitragseinreichung bestätigen"
+
+msgid "author.submit.upload"
+msgstr "Konferenzbeitrag hochladen"
+
+msgid "submission.submit.cancelSubmission"
+msgstr "Sie können diesen Konferenzbeitrag zum Konferenzband zu einem späteren Zeitpunkt vervollständigen, indem Sie „Aktive Konferenzbandbeiträge“ im Autoren-Startbereich auswählen."
+
+msgid "author.submit.notAccepting"
+msgstr "Die Konferenzband nimmt zur Zeit keine Beiträge an."
+
+msgid "author.submit.qualifyForWaiver"
+msgstr "Bitte ziehen Sie einen Verzicht auf die Konferenzbeitragseinreichungsgebühr für diesen Konferenzbeitrag in Erwägung"
+
+msgid "author.submissions.confirmDelete"
+msgstr "Sind Sie sicher, dass Sie diese unvollständige Konferenzbeitragseinreichung löschen wollen?"
+
+msgid "author.submissions.noSubmissions"
+msgstr "Keine Konferenzbeitragseinreichungen."
+
+msgid "author.submit.journalSection"
+msgstr "Konferenzbandrubrik"
+
+msgid "author.submit.journalSectionDescription"
+msgstr "Konferenzbeiträge müssen in einer der Rubriken des Konferenzbandes eingereicht werden."
+
+msgid "author.submit.verifyChecklist"
+msgstr "Stellen Sie sicher, dass alle Punkte der Checkliste erfüllt sind, bevor Sie fortfahren."
+
+msgid "author.submit.copyrightNoticeAgree"
+msgstr "Die Autoren stimmen den Bedingungen dieser Urheberrechtsmitteilung zu, die auf diesen Konferenzbandbeitrag angewendet werden, wenn und sobald er von dieser Konferenzbandsreihe veröffentlicht wird (Anmerkungen an den Herausgeber können unten hinzugefügt werden)."
+
+msgid "author.submit.form.sectionRequired"
+msgstr "Bitte wählen Sie eine passende Rubrik der Konferenzbandreihe für diesen Konferenzbandbeitrag aus."
+
+msgid "author.submit.form.localeRequired"
+msgstr "Bitte wählen Sie eine Konferenzbeitragssprache."
+
+msgid "submission.submit.privacyStatement"
+msgstr "Datenschutzerklärung der Konferenzbandreihe"
+
+msgid "author.submit.submissionIndexingDescription"
+msgstr "Stellen Sie Begriffe für die Indizierung des Konferenzbeitrages zusammen; trennen Sie diese Begriffe durch ein Semikolon (Begriff1; Begriff2; Begriff3)."
+
+msgid "author.submit.form.titleRequired"
+msgstr "Bitte den Titel Ihres Konferenzbeitrages eingeben."
+
+msgid "author.submit.form.abstractRequired"
+msgstr "Geben Sie bitte ein Abstract Ihres Konferenzbeitrages ein."
+
+msgid "author.submit.submissionFile"
+msgstr "Konferenzbeitragsdatei"
+
+msgid "author.submit.uploadSubmissionFile"
+msgstr "Konferenzbeitragsdatei hochladen"
+
+msgid "author.submit.replaceSubmissionFile"
+msgstr "Konferenzbeitragsdatei ersetzen"
+
+msgid "author.submit.noSubmissionFile"
+msgstr "Keine Konferenzbeitragsdatei hochgeladen."
+
+msgid "author.submit.noSubmissionConfirm"
+msgstr "Sind Sie sicher, dass Sie fortfahren wollen, ohne eine Konferenzbeitragsdatei hochgeladen zu haben?"
+
+msgid "author.submit.supplementaryFilesInstructions"
+msgstr "Dieser optionale Schritt ermöglicht das Hinzufügen zusätzlicher Dateien zum Konferenzbeitrag. Die Dateien, die in jedem Format vorliegen können, können (a) Forschungsinstrumente, (b) Datensätze, die mit der Forschungsethik der Untersuchung übereinstimmen, (c) Quellen, die den Leser/innen sonst nicht zugänglich wären, (d) Zahlen und Tabellen, die nicht in den Text selbst eingebaut werden können, oder anderes Material, das zu der Arbeit beiträgt, enthalten."
+
+msgid "author.submit.noSupplementaryFiles"
+msgstr "Der Konferenzbeitragseinreichung wurden keine Zusatzdateien angefügt."
+
+msgid "author.submit.confirmationDescription"
+msgstr "Um Ihr Manuskript an {$journalTitle} zu übermitteln, klicken Sie auf „Einreichung abschließen“. Die Hauptkontaktperson der Einreichung wird eine Bestätigung per E-Mail erhalten und kann den Fortschritt der Konferenzbandbeitragseinreichung durch den redaktionellen Prozess verfolgen, indem sie sich auf der Website der Zeitschrift anmeldet. Vielen Dank für Ihr Interesse daran, mit {$journalTitle} zu veröffentlichen."
+
+msgid "author.submit.noFiles"
+msgstr "Es wurden keine Dateien an diese Konferenzbandbeitragseinreichung angehängt."
+
+msgid "author.submit.finishSubmission"
+msgstr "Konferenzbeitragseinreichung abschließen"
+
+msgid "author.submit.submissionComplete"
+msgstr "Die Konferenzbeitragseinreichung ist abgeschlossen. Vielen Dank für Ihr Interesse an einer Veröffentlichung bei {$journalTitle}."
+
+msgid "author.submit.authorSubmitLoginMessage"
+msgstr "Um Beiträge bei dieser Konferenzband einzureichen, ist ein Benutzer/innen-Konto erforderlich. Dies ermöglicht es unserer Redaktion, Ihre Beiträge zu verfolgen und Sie zu kontaktieren, wenn sich der Status Ihres Beitrags ändert oder wenn zusätzliche Informationen von Ihnen benötigt werden."
+

--- a/customLocale/de_DE/locale/de_DE/default.po
+++ b/customLocale/de_DE/locale/de_DE/default.po
@@ -1,0 +1,45 @@
+msgid "section.default.title"
+msgstr "Konferenzbeitrag"
+
+msgid "default.genres.article"
+msgstr "Konferenzbeitragtext"
+
+msgid "default.contextSettings.checklist.notPreviouslyPublished"
+msgstr "Der Konferenzbeitrag ist bisher unveröffentlicht und wurde auch keiner anderen Konferenzbandreihe vorgelegt (andernfalls ist eine Erklärung in \"Kommentare für die Redaktion\" beigefügt)."
+
+msgid "default.contextSettings.checklist.fileFormat"
+msgstr "Die Konferenzbeitragsdatei liegt im Format OpenOffice, Microsoft Word oder RTF vor."
+
+msgid "default.contextSettings.privacyStatement"
+msgstr "<p>Namen und E-Mail-Adressen, die auf den Webseiten des Konferenzbandes eingegeben werden, werden ausschließlich zu den angegebenen Zwecken verwendet und nicht an Dritte weitergegeben.</p>"
+
+msgid "default.contextSettings.openAccessPolicy"
+msgstr "Diese Konferenzband bietet freien Zugang (Open Access) zu ihren Inhalten, entsprechend der Grundannahme, dass die freie öffentliche Verfügbarkeit von Forschung einem weltweiten Wissensaustausch zugute kommt."
+
+msgid "default.contextSettings.forReaders"
+msgstr "Wir empfehlen unseren Leser/innen, sich für die Benachrichtigung bei neuen Veröffentlichungen dieses Konferenzbandes einzutragen. Verwenden Sie den <a href=\{$indexUrl}/{$contextPath}/user/register\>Registrieren</a>-Link oben auf der Startseite des Konferenzbandes. Angemeldete Leser/innen erhalten zu jeder neuen Ausgabe der Konferenzbandereihe die Inhaltsangabe per E-Mail zugeschickt. Die Anmeldung ermöglicht es gleichzeitig der Konferenzband, einen gewissen Grad an Unterstützung oder eine gewisse Leser/innenschaft zu belegen. Siehe die Regelungen zum <a href=\{$indexUrl}/{$contextPath}/about/submissions#privacyStatement\>Schutz personenbezogener Daten</a> der Konferenzbandreihe, die sicherstellen, dass weder Namen noch E-Mail-Adressen registrierter Benutzer/innen zu anderen Zwecken verwendet werden."
+
+msgid "default.contextSettings.forAuthors"
+msgstr "Haben Sie Interesse, einen Beitrag bei diesem Konferenzband einzureichen? Wir möchten Sie auf <a href=\{$indexUrl}/{$contextPath}/about\>Über uns</a>, wo Sie die Richtlinien des Konferenzbandes einsehen können, und auf <a href=\{$indexUrl}/{$contextPath}/about/submissions#authorGuidelines\>Richtlinien für Autor/innen</a> verweisen. Autor/innen müssen sich <a href=\{$indexUrl}/{$contextPath}/user/register\>registrieren</a>, bevor Sie einen Beitrag für den Konferenzband einreichen können. Falls Sie bereits angemeldet sind, einfach <a href=\{$indexUrl}/{$contextPath}/login\>einloggen</a> und die \"Fünf Schritte zur Konferenzbeitragseinreichung\" abarbeiten."
+
+msgid "default.contextSettings.forLibrarians"
+msgstr "Wir ermutigen Forschungsbibliotheken, diesen Konferenzband in die Liste ihrer elektronischen Konferenzbände aufzunehmen. Darüber hinaus bietet das Open Source Veröffentlichungssystem dieser Konferenzbandreihe Bibliotheken die Möglichkeit, Konferenzbände, an denen Mitglieder ihrer Fakultät mitarbeiten, online bereitzustellen. Siehe <a href=\http://pkp.sfu.ca\>Public Knowledge Project</a>."
+
+msgid "default.contextSettings.lockssLicense"
+msgstr "Diese Konferenzbandreihe verwendet das LOCKSS-System, um mit Hilfe der teilnehmenden Bibliotheken ein dezentralen Achivierungssystem zu schaffen, bei dem diese Bibliotheken die Konferenzband zu Aufbewahrungs- und Wiederherstellungszwecken permanent archivieren. <a href=\http://www.lockss.org/\>Mehr...</a>"
+
+msgid "default.contextSettings.clockssLicense"
+msgstr "Diese Konferenzbandreihe benutzt das CLOCKSS-System, um ein verteiltes Archivsystem zwischen teilnehmenden Bibliotheken zu ermöglichen. Sie erlaubt diesen Bibliotheken, dauerhafte Archive des Konferenzbandes zu Zwecken des Bewahrens und Wiederherstellens anzulegen. <a href=\http://clockss.org/\>Mehr...</a>"
+
+msgid "default.groups.name.manager"
+msgstr "Konferenzbandverwalter/in"
+
+msgid "default.groups.plural.manager"
+msgstr "Konferenzbandverwalter/innen"
+
+msgid "default.groups.name.editor"
+msgstr "Konferenzbandredakteur/in"
+
+msgid "default.groups.plural.editor"
+msgstr "Konferenzbandredakteur/innen"
+

--- a/customLocale/de_DE/locale/de_DE/editor.po
+++ b/customLocale/de_DE/locale/de_DE/editor.po
@@ -1,0 +1,132 @@
+msgid "editor.submissionsAndPublishing"
+msgstr "Konferenzbeiträge und Veröffentlichungen"
+
+msgid "editor.submissionQueue"
+msgstr "Liste der Konferenzbeiträge"
+
+msgid "editor.submissionArchive"
+msgstr "Konferenzbeitragsarchiv"
+
+msgid "editor.publishedIssues"
+msgstr "Veröffentlichte Konferenzbände"
+
+msgid "editor.submissionArchive.noSubmissions"
+msgstr "Keine Konferenzbeiträge im Archiv."
+
+msgid "editor.notifyUsers.includeToc"
+msgstr "Das Inhaltsverzeichnis dieses Konferenzbandes anfügen:"
+
+msgid "editor.issues.createIssue"
+msgstr "Konferenzband erstellen"
+
+msgid "editor.issues.editIssue"
+msgstr "Konferenzbandverwaltung: {$issueIdentification}"
+
+msgid "editor.issues.currentIssue"
+msgstr "Aktueller Konferenzband"
+
+msgid "editor.issues.noArticles"
+msgstr "Zur Zeit ist kein Beitrag zur Veröffentlichung in diesem Konferenzband vorgesehen."
+
+msgid "editor.issues.confirmDelete"
+msgstr "Sind Sie sicher, dass Sie diesen Konferenzband endgültig löschen wollen?"
+
+msgid "editor.issues.titleRequired"
+msgstr "Die Angabe \Titel\ ist erforderlich."
+
+msgid "editor.issues.issueIdentification"
+msgstr "Konferenzbandkennzeichnung"
+
+msgid "editor.issues.publicIssueIdentifier"
+msgstr "Öffentliche Konferenzbandkennzeichnung"
+
+msgid "editor.issues.showCoverPage"
+msgstr "Erstellen Sie für diesen Konferenzband eine Titelseite mit den folgenden Bestandteilen:"
+
+msgid "editor.issues.issueData"
+msgstr "Daten des Konferenzbandes"
+
+msgid "editor.issues.publishIssue"
+msgstr "Konferenzband veröffentlichen"
+
+msgid "editor.issues.unpublishIssue"
+msgstr "Konferenzband zurückziehen"
+
+msgid "editor.issues.previewIssue"
+msgstr "Voransicht des Konferenzbandes"
+
+msgid "editor.issues.confirmPublish"
+msgstr "Sind Sie sicher, dass Sie den neuen Konferenzband veröffentlichen wollen?"
+
+msgid "editor.issues.confirmUnpublish"
+msgstr "Sind sie sicher, dass Sie diesen bereits veröffentlichten Konferenzband zurückziehen wollen?"
+
+msgid "editor.issues.confirmSetCurrentIssue"
+msgstr "Sind Sie sicher, dass Sie diesen Konferenzband als aktuellen Konferenzband festlegen möchten?"
+
+msgid "editor.issues.publicArticleIdExists"
+msgstr "Die öffentliche Kennzeichnung für den folgenden Konferenzbeitrag konnte nicht gespeichert werden:"
+
+msgid "editor.issues.noLiveIssues"
+msgstr "Keine aktueller Konferenzband"
+
+msgid "editor.issues.galleys"
+msgstr "Konferenzbandfahnen"
+
+msgid "editor.issues.galley"
+msgstr "Konferenzbandfahne"
+
+msgid "editor.issues.viewingGalley"
+msgstr "Konferenzbandfahne ansehen"
+
+msgid "editor.issues.issueGalleysDescription"
+msgstr "Fahnen mit dem Inhalt der gesamten Konferenzband veröffentlichen."
+
+msgid "editor.issues.noneIssueGalleys"
+msgstr "Es wurden keine Konferenzbandfahnen veröffentlicht."
+
+msgid "editor.issues.galleyLabelRequired"
+msgstr "Eine Kennung für die Konferenzbandfahne wird benötigt."
+
+msgid "editor.issues.galleyLocaleRequired"
+msgstr "Eine Regionaleinstellung für die Konferenzbandfahne wird benötigt."
+
+msgid "editor.issues.galleyPublicIdentificationExists"
+msgstr "Die öffentliche Kennung der Konferenzbandfahne existiert bereits."
+
+msgid "editor.issues.backToIssueGalleys"
+msgstr "Zurück zu den Konferenzbandfahnen"
+
+msgid "editor.issues.confirmDeleteGalley"
+msgstr "Sind Sie sicher, dass Sie diese Konferenzbandfahne löschen möchten?"
+
+msgid "editor.navigation.futureIssues"
+msgstr "Zukünftiger Konferenzband"
+
+msgid "grid.action.publish"
+msgstr "Konferenzband veröffentlichen"
+
+msgid "grid.action.addIssue"
+msgstr "Konferenzband anlegen"
+
+msgid "grid.action.addIssueGalley"
+msgstr "Konferenzbandfahne anlegen"
+
+msgid "grid.action.setCurrentIssue"
+msgstr "Aktuelle Konferenzband festlegen"
+
+msgid "editor.navigation.issueArchive"
+msgstr "Früherer Konferenzband"
+
+msgid "editor.submissions.noSubmissions"
+msgstr "Keine Konferenzbeiträge"
+
+msgid "issues.submissions.issueIds"
+msgstr "Zugeordnet zu Konferenzband"
+
+msgid "grid.action.removeArticle"
+msgstr "Konferenzbeitrag aus dem Konferenzband entfernen"
+
+msgid "editor.issues.editIssueGalley"
+msgstr "Konferenzbandfahne bearbeiten"
+

--- a/customLocale/de_DE/locale/de_DE/emails.po
+++ b/customLocale/de_DE/locale/de_DE/emails.po
@@ -1,0 +1,157 @@
+
+msgid "emails.userRegister.subject"
+msgstr "Registrierung bei dem Konferenzband"
+
+msgid "emails.publishNotify.subject"
+msgstr "Neuer Konferenzband veröffentlicht"
+
+msgid "emails.publishNotify.description"
+msgstr "Diese E-Mail wird an registrierte Leser über den Link \Benutzer benachrichtigen\ im Benutzer-Startbereich des Herausgebers gesendet. Sie informiert die Leser über einen neuen Konferenzband und lädt sie ein, die Konferenzbandreihe unter einer angegebenen URL zu besuchen."
+
+msgid "emails.lockssExistingArchive.description"
+msgstr "Diese E-Mail bittet den Verwalter eines LOCKSS-Archivs, die Aufnahme dieser Zeitschrift in ihr Archiv in Erwägung zu ziehen. Sie stellt die URL zum LOCKSS Publisher Manifest der Konferenzbandreihe bereit."
+
+msgid "emails.lockssNewArchive.description"
+msgstr  "Diese E-Mail ermutigt den Empfänger, an der LOCKSS-Initiative teilzunehmen und diese Konferenzbandreihe in das Archiv aufzunehmen. Sie liefert Informationen über die LOCKSS-Initiative und Möglichkeiten zur Beteiligung."
+
+msgid "emails.submissionAck.subject"
+msgstr "Bestätigung der Einreichung des Konferenzbandbeitrags"
+
+msgid "emails.submissionAck.description"
+msgstr "Diese E-Mail wird, wenn aktiviert, automatisch an einen Autor gesendet, wenn er den Prozess der Einreichung eines Manuskripts bei der Konferenzbandreihe abgeschlossen hat. Sie liefert Informationen über das Tracking der Einreichung durch den Prozess und dankt dem Autor für die Einreichung des Konferenzbandbeitrags."
+
+msgid "emails.submissionAckNotUser.subject"
+msgstr "Bestätigung der Einreichung des Konferenzbandbeitrags"
+
+msgid "emails.submissionAckNotUser.description"
+msgstr "Diese E-Mail wird, wenn aktiviert, automatisch an die anderen Autoren gesendet, die während des Einreichungsprozesses des Konferenzbandbeitrags nicht als Benutzer im OJS spezifiziert wurden."
+
+msgid "emails.editorAssign.description"
+msgstr "Diese E-Mail benachrichtigt einen Rubrikherausgeber darüber, dass der Herausgeber ihm die Aufgabe übertragen hat, eine Einreichung durch den Bearbeitungsprozess zu begleiten. Sie liefert Informationen über die Einreichung des Konferenzbandbeitrags und wie man auf die Website der Konferenzbandreihe zugreifen kann."
+
+msgid "emails.reviewRequest.subject"
+msgstr "Einladung zur Begutachtung"
+
+msgid "emails.reviewRequest.description"
+msgstr "Diese E-Mail vom Rubrikherausgeber an einen Gutachter bittet diesen, die Aufgabe der Begutachtung einer Konferenzbandeinreichung zu akzeptieren oder abzulehnen. Sie liefert Informationen über die Einreichung wie Titel und Abstract, ein Abgabedatum für das Gutachten und wie man auf die Einreichung des Konferenzbandbeitrags selbst zugreifen kann. Diese Nachricht wird verwendet, wenn der Standard-Überprüfungsprozess in Management > Einstellungen > Workflow > Gutachten ausgewählt ist. (Andernfalls siehe REVIEW_REQUEST_ATTACHED.)"
+
+msgid "emails.reviewRequestRemindAuto.subject"
+msgstr "Erinnerung an die Gutachtenanfrage für die Konferenzbeitragseinreichung"
+
+msgid "emails.reviewRequestOneclick.subject"
+msgstr "Gutachtenanfrage für die Konferenzbeitragseinreichung"
+
+msgid "emails.reviewRequestOneclick.description"
+msgstr "Diese E-Mail vom Rubrikherausgeber an einen Gutachter bittet diesen, die Aufgabe der Begutachtung einer Konferenzbandeinreichung zu akzeptieren oder abzulehnen. Sie liefert Informationen über die Einreichung wie Titel und Abstract, ein Abgabedatum für das Gutachten und wie man auf die Einreichung des Konferenzbandbeitrags selbst zugreifen kann. Diese Nachricht wird verwendet, wenn der Standard-Überprüfungsprozess in Management > Einstellungen > Workflow > Gutachten ausgewählt ist und der Zugriff auf den Gutachter mit einem Klick aktiviert ist."
+
+msgid "emails.reviewRequestRemindAutoOneclick.subject"
+msgstr "Überprüfungsanfrage für den Konferenzbandbeitrag"
+
+msgid "emails.reviewRequestAttached.subject"
+msgstr "Überprüfungsanfrage für den Konferenzbandbeitrag"
+
+msgid "emails.reviewRequestAttached.description"
+msgstr  "Diese E-Mail wird vom Rubrikherausgeber an einen Gutachter gesendet, um diesen zu bitten, die Aufgabe der Begutachtung einer Einreichung zu akzeptieren oder abzulehnen. Sie enthält die Einreichung des Konferenzbandbeitrags als Anhang. Diese Nachricht wird verwendet, wenn der Überprüfungsprozess per E-Mail-Anhang in Management > Einstellungen > Workflow > Gutachten ausgewählt ist. (Andernfalls siehe REVIEW_REQUEST.)"
+
+msgid "emails.reviewRequestSubsequent.subject"
+msgstr "Anfrage zur Begutachtung einer überarbeiteten Konferenzbeitragseinreichung"
+
+msgid "emails.reviewRequestSubsequent.description"
+msgstr "Diese E-Mail vom Rubrikherausgeber an einen Gutachter bittet diesen, die Aufgabe der Begutachtung einer Einreichung für eine zweite oder weitere Runde der Überprüfung zu akzeptieren oder abzulehnen. Sie liefert Informationen über die Einreichung wie Titel und Abstract, ein Abgabedatum für das Gutachten und wie man auf die Einreichung des Konferenzbandbeitrags selbst zugreifen kann. Diese Nachricht wird verwendet, wenn der Standard-Überprüfungsprozess in Management > Einstellungen > Workflow > Gutachten ausgewählt ist. (Andernfalls siehe REVIEW_REQUEST_ATTACHED_SUBSEQUENT.)"
+
+msgid "emails.reviewRequestOneclickSubsequent.subject"
+msgstr "Überprüfungsanfrage für die Konferenzbeitragseinreichung"
+
+msgid "emails.reviewRequestOneclickSubsequent.description"
+msgstr "Diese E-Mail vom Rubrikherausgeber an einen Gutachter bittet diesen, die Aufgabe der Begutachtung einer Einreichung für eine zweite oder weitere Runde der Überprüfung zu akzeptieren oder abzulehnen. Sie liefert Informationen über die Einreichung wie Titel und Abstract, ein Abgabedatum für das Gutachten und wie man auf die Einreichung des Konferenzbandbeitrags selbst zugreifen kann. Diese Nachricht wird verwendet, wenn der Standard-Überprüfungsprozess in Management > Einstellungen > Workflow > Gutachten ausgewählt ist und der Zugriff auf den Gutachter mit einem Klick aktiviert ist."
+
+msgid "emails.reviewRequestAttachedSubsequent.subject"
+msgstr "Überprüfungsanfrage für die Konferenzbeitragseinreichung"
+
+msgid "emails.reviewRequestAttachedSubsequent.description"
+msgstr "Diese E-Mail wird vom Rubrikherausgeber an einen Gutachter gesendet, um diesen zu bitten, die Aufgabe der Begutachtung einer Einreichung für eine zweite oder weitere Runde der Überprüfung zu akzeptieren oder abzulehnen. Sie enthält die Einreichung des Konferenzbandbeitrags als Anhang. Diese Nachricht wird verwendet, wenn der Überprüfungsprozess per E-Mail-Anhang in Management > Einstellungen > Workflow > Gutachten ausgewählt ist. (Andernfalls siehe REVIEW_REQUEST_SUBSEQUENT.)"
+
+msgid "emails.reviewCancel.description"
+msgstr "Diese E-Mail wird vom Rubrikherausgeber an einen Gutachter gesendet, der gerade eine Begutachtung einer Konferenzbeitragseinreichung durchführt, um ihn darüber zu informieren, dass die Begutachtung abgebrochen wurde."
+
+msgid "emails.reviewReinstate.description"
+msgstr "Diese E-Mail wird vom Rubrikherausgeber an einen Gutachter gesendet, der gerade eine Begutachtung einer Konferenzbeitragseinreichung durchführt, um ihn darüber zu informieren, dass eine abgebrochene Begutachtung wiederhergestellt wurde."
+
+msgid "emails.reviewAck.subject"
+msgstr "Bestätigung der Begutachtung der Konferenzbeitragseinreichung"
+
+msgid "emails.reviewRemind.subject"
+msgstr "Eine Erinnerung, Ihr Gutachten bitte abzuschließen"
+
+msgid "emails.reviewRemindOneclick.subject"
+msgstr "Erinnerung an die Begutachtung der Konferenzbeitragseinreichung"
+
+msgid "emails.reviewRemindAuto.subject"
+msgstr "Eine Erinnerung, Ihr Gutachten bitte abzuschließen"
+
+msgid "emails.reviewRemindAutoOneclick.subject"
+msgstr "Automatische Erinnerung an die Begutachtung der Konferenzbeitragseinreichung"
+
+msgid "emails.editorDecisionAccept.description"
+msgstr "Diese E-Mail vom Herausgeber oder Rubrikherausgeber an einen Autor informiert diesen über die endgültige Entscheidung zur \Annahme\ seiner Konferenzbeitragseinreichung."
+
+msgid "emails.editorDecisionSendToExternal.description"
+msgstr "Diese E-Mail vom Herausgeber oder Rubrikherausgeber an einen Autor informiert diesen, dass seine Konferenzbeitragseinreichung zur externen Begutachtung gesendet wird."
+
+msgid "emails.editorDecisionSendToProduction.description"
+msgstr "Diese E-Mail vom Herausgeber oder Rubrikherausgeber an einen Autor informiert diesen, dass seine Konferenzbeitragseinreichung in die Produktion übergeht."
+
+msgid "emails.editorDecisionRevisions.description"
+msgstr "Diese E-Mail vom Herausgeber oder Rubrikherausgeber an einen Autor informiert diesen über die endgültige Entscheidung, dass an seiner Konferenzbeitragseinreichung \Überarbeitungen erforderlich\ sind."
+
+msgid "emails.editorDecisionResubmit.description"
+msgstr "Diese E-Mail vom Herausgeber oder Rubrikherausgeber an einen Autor informiert diesen über die endgültige Entscheidung, dass seine Konferenzbeitragseinreichung \erneut eingereicht\ werden muss."
+
+msgid "emails.editorDecisionDecline.description"
+msgstr "Diese E-Mail vom Herausgeber oder Rubrikherausgeber an einen Autor informiert diesen über die endgültige Entscheidung, dass seine Konferenzbeitragseinreichung \abgelehnt\ wurde."
+
+msgid "emails.editorRecommendation.description"
+msgstr "Diese E-Mail vom empfehlenden Herausgeber oder Rubrikherausgeber an die entscheidenden Herausgeber oder Rubrikherausgeber informiert sie über eine endgültige Empfehlung bezüglich der Konferenzbeitragseinreichung."
+
+msgid "emails.copyeditRequest.description"
+msgstr "Diese E-Mail wird von einem Rubrikherausgeber an den Lektor eines Beitrags gesendet, um diesen aufzufordern, mit dem Lektoratsprozess zu beginnen. Sie enthält Informationen über die Konferenzbeitragseinreichung und darüber, wie darauf zugegriffen werden kann."
+
+msgid "emails.layoutRequest.description"
+msgstr "Diese E-Mail vom Rubrikherausgeber an den Layout-Editor informiert diesen, dass er mit der Aufgabe betraut wurde, das Layout für einen Beitrag zu bearbeiten. Sie enthält Informationen über die Einreichung des Konferenzbandbeitrags und darüber, wie darauf zugegriffen werden kann."
+
+msgid "emails.emailLink.subject"
+msgstr "Möglicherweise interessanter Konferenzbeitrag"
+
+msgid "emails.emailLink.body"
+msgstr "Ich dachte, dass Sie vielleicht Interesse daran haben könnten, „{$submissionTitle}“ von {$authorName} zu sehen, veröffentlicht in Konferenzband {$volume}, Nummer {$number} ({$year}) von {$contextName} unter „{$submissionUrl}“."
+
+msgid "emails.emailLink.description"
+msgstr "Diese E-Mail-Vorlage bietet registrierten Leser/innen die Möglichkeit, Informationen über einen Konferenzbeitrag an eine interessierte Person zu senden. Sie ist über die Reading Tools verfügbar und muss von dem/der Konferenzbandemanager/in auf der Verwaltungsseite der Reading Tools aktiviert werden."
+
+msgid "emails.subscriptionNotify.description"
+msgstr "Diese E-Mail benachrichtigt einen registrierten Leser, dass der Manager ein Abonnement für sie/ihn erstellt hat. Sie enthält die URL der Konferenzbandreihe sowie Hinweise für den Zugang."
+
+msgid "emails.openAccessNotify.subject"
+msgstr "Konferenzband ist jetzt Open Access"
+
+msgid "emails.openAccessNotify.description"
+msgstr  "Diese E-Mail wird an registrierte Leser gesendet, die angefordert haben, eine Benachrichtigungs-E-Mail zu erhalten, wenn ein Konferenzband Open Access wird."
+
+msgid "emails.subscriptionBeforeExpiry.description"
+msgstr "Diese E-Mail benachrichtigt einen Abonnenten darüber, dass sein Abonnement bald ablaufen wird. Sie enthält die URL der Konferenzbandreihe sowie Anweisungen für den Zugang."
+
+msgid "emails.subscriptionAfterExpiry.description"
+msgstr "Diese E-Mail benachrichtigt einen Abonnenten darüber, dass sein Abonnement abgelaufen ist. Sie enthält die URL der Konferenzbandreihe sowie Anweisungen für den Zugang."
+
+msgid "emails.subscriptionAfterExpiryLast.description"
+msgstr "Diese E-Mail benachrichtigt einen Abonnenten darüber, dass sein Abonnement abgelaufen ist. Sie enthält die URL der Konferenzbandreihe sowie Anweisungen für den Zugang."
+
+msgid "emails.revisedVersionNotify.description"
+msgstr "Diese E-Mail wird automatisch an den zugewiesenen Editor gesendet, wenn der Autor eine überarbeitete Version einer Konferenzbeitragseinreichung hochlädt."
+
+msgid "emails.editorDecisionInitialDecline.description"
+msgstr "Diese E-Mail wird an den Autor gesendet, wenn der Editor seine Konferenzbandeinreichung initial ablehnt, noch bevor die Überprüfungsphase beginnt."
+
+msgid "emails.statisticsReportNotification.description"
+msgstr "Diese E-Mail wird automatisch monatlich an Editoren und Manager der Konferenzbandreihe gesendet, um ihnen einen Überblick über den Zustand des Systems zu geben."
+

--- a/customLocale/de_DE/locale/de_DE/locale.po
+++ b/customLocale/de_DE/locale/de_DE/locale.po
@@ -1,0 +1,416 @@
+msgid "user.authorization.journalDoesNotPublish"
+msgstr "Dieser Konferenzband veröffentlicht seinen Inhalt nicht online."
+
+msgid "context.current"
+msgstr "Aktueller Konferenzband:"
+
+msgid "context.select"
+msgstr "Zu einem anderen Konferenzband wechseln:"
+
+msgid "common.software"
+msgstr "Open Journal Systems"
+
+msgid "common.journalHomepageImage.altText"
+msgstr "Bild auf der Startseite des Konferenzbands"
+
+msgid "navigation.journalHelp"
+msgstr "Navigationshilfe"
+
+msgid "navigation.otherJournals"
+msgstr "Andere Konferenzbände"
+
+msgid "navigation.browseByIssue"
+msgstr "Nach Konferenzband"
+
+msgid "navigation.skip.about"
+msgstr "Zu \Über uns\ springen"
+
+msgid "navigation.skip.issue"
+msgstr "Zum aktuellen Konferenzband springen"
+
+msgid "common.queue.long.submissionsInEditing"
+msgstr "In redaktioneller Bearbeitung"
+
+msgid "common.queue.long.submissionsInReview"
+msgstr "Konferenzbeiträge in Begutachtung"
+
+msgid "section.abbreviation.example"
+msgstr "(Zum Beispiel, Konferenzbeitrag=ART)"
+
+msgid "article.article"
+msgstr "Konferenzbeitrag"
+
+msgid "article.articles"
+msgstr "Konferenzbeitrag"
+
+msgid "common.publication"
+msgstr "Konferenzbeitrag"
+
+msgid "common.publications"
+msgstr "Konferenzbeitrag"
+
+msgid "article.submissionId"
+msgstr "Konferenzbeitrags-ID"
+
+msgid "article.journalSection"
+msgstr "Rubrik"
+
+msgid "article.submission"
+msgstr "Konferenzbeitrag"
+
+msgid "article.submissions"
+msgstr "Konferenzbeiträge"
+
+msgid "article.return"
+msgstr "Zu Konferenzbeitragdetails zurückkehren"
+
+msgid "submission.submissionEditing"
+msgstr "Redaktionelle Bearbeitung des Konferenzbeitrags"
+
+msgid "submission.scheduledIn"
+msgstr "Veröffentlichung geplant für {$issueName}."
+
+msgid "submission.search"
+msgstr "Konferenzbeitragsuche"
+
+msgid "journal.currentIssue"
+msgstr "Aktueller Konferenzband"
+
+msgid "context.contexts"
+msgstr "Konferenzbände"
+
+msgid "context.context"
+msgstr "Konferenzband"
+
+msgid "journal.viewAllIssues"
+msgstr "Alle Konferenzbände anzeigen"
+
+msgid "user.noRoles.selectUsersWithoutRoles"
+msgstr "Nutzer/innen ohne Rolle in diesen Konferenzband mit aufnehmen."
+
+msgid "user.showAllJournals"
+msgstr "Alle Konferenzbände anzeigen"
+
+msgid "user.registerForOtherJournals"
+msgstr "Für andere Konferenzbände registrieren"
+
+msgid "user.reviewerPrompt"
+msgstr "Wären Sie daran interessiert, Konferenzbeiträge in diesem Konferenzband zu begutachten?"
+
+msgid "user.register.contextsPrompt"
+msgstr "Bei welchen Konferenzbänden auf dieser Website möchten Sie sich registrieren?"
+
+msgid "user.myJournals"
+msgstr "Meine Konferenzbände"
+
+msgid "user.noRoles.submitArticleRegClosed"
+msgstr "Einen Vorschlag einreichen: Registrierung als Autor/in ist momentan ausgeschaltet."
+
+msgid "user.role.manager"
+msgstr "Konferenzbandverwalter/in"
+
+msgid "user.role.managers"
+msgstr "Konferenzbandverwalter/innen"
+
+msgid "user.role.journalAssistant"
+msgstr "Konferenzbandassistent/in"
+
+msgid "user.role.journalAssistants"
+msgstr "Konferenzbandassistent/innen"
+
+msgid "issue.issue"
+msgstr "Konferenzband"
+
+msgid "issue.issues"
+msgstr "Konferenzbände"
+
+msgid "issue.noIssues"
+msgstr "Keine Konferenzbände"
+
+msgid "issue.fullIssue"
+msgstr "Kompletter Konferenzband"
+
+msgid "issue.nonpdf.title"
+msgstr "Konferenzbände-Download"
+
+msgid "issue.viewIssue"
+msgstr "Konferenzband ansehen"
+
+msgid "issue.return"
+msgstr "Zu Konferenzbanddetails zurückkehren"
+
+msgid "submission.event.general.defaultEvent"
+msgstr "Neuzugang"
+
+msgid "submission.event.submissionSubmitted"
+msgstr "Konferenzbeitrag eingereicht"
+
+msgid "submission.event.general.issueScheduled"
+msgstr "Konferenzbeitrag an die Warteliste für die Konferenzbandplanung geschickt"
+
+msgid "submission.event.general.issueAssigned"
+msgstr "Konferenzbeitrag einem Konferenzband zugewiesen"
+
+msgid "submission.event.general.articlePublished"
+msgstr "Konferenzbeitrag veröffentlicht"
+
+msgid "submission.event.editor.editorAssigned"
+msgstr "Konferenzbeitrag einer Redakteurin/einem Redakteur zugeteilt"
+
+msgid "submission.event.editor.editorUnassigned"
+msgstr "Redakteur/in nicht länger für den Konferenzbeitrag zuständig"
+
+msgid "submission.event.editor.submissionArchived"
+msgstr "Konferenzbeitrag ans Archiv geschickt"
+
+msgid "submission.event.editor.submissionRestored"
+msgstr "Konferenzbeitrag aus dem Archiv wiederhergestellt"
+
+msgid "submission.event.copyedit.copyeditorAssigned"
+msgstr "Konferenzbeitrag einer Lektorin/einem Lektor zugeteilt"
+
+msgid "submission.event.copyedit.copyeditorUnassigned"
+msgstr "Lektor/in nicht länger für den Konferenzbeitrag zuständig"
+
+msgid "submission.event.proofread.proofreaderAssigned"
+msgstr "Konferenzbeitrag einer Korrekturlektorin/einem Korrekturlektor zugeteilt"
+
+msgid "submission.event.proofread.proofreaderUnassigned"
+msgstr "Korrekturlektor/in nicht länger für den Konferenzbeitrag zuständig"
+
+msgid "submission.event.layout.layoutEditorAssigned"
+msgstr "Konferenzbeitrag einer Layoutredakteurin/einem Layoutredakteur zugeteilt"
+
+msgid "submission.event.layout.layoutEditorUnassigned"
+msgstr "Layoutredakteur/in nicht länger für den Konferenzbeitrag zuständig"
+
+msgid "comments.commentsOnArticle"
+msgstr "Kommentare zu diesem Konferenzbeitrag"
+
+msgid "search.results.orderBy.article"
+msgstr "Konferenzbeitragtitel"
+
+msgid "search.results.orderBy.issue"
+msgstr "Konferenzbandtitel"
+
+msgid "search.results.orderBy.journal"
+msgstr "Konferenzbandreihentitel"
+
+msgid "plugins.categories.viewableFiles"
+msgstr "Plugins für Konferenzbeitragfahnen"
+
+msgid "sectionEditor.noneAssigned"
+msgstr "Keine Konferenzbeiträge zugewiesen."
+
+msgid "sectionEditor.regrets.title"
+msgstr "#{$submissionId} Absagen durch Gutachter/innen, Abbrüche & Frühere Durchgänge"
+
+msgid "reviewer.pendingReviews"
+msgstr "Konferenzbeiträge in Begutachtung"
+
+msgid "reviewer.article.submissionEditor"
+msgstr "Zuständige/r Redakteur/in"
+
+msgid "reviewer.article.decision.accept"
+msgstr "Konferenzbeitrag annehmen"
+
+msgid "reviewer.article.decision.decline"
+msgstr "Konferenzbeitrag ablehnen"
+
+msgid "reviewer.article.submissionToBeReviewed"
+msgstr "Konferenzbeitrag zur Begutachtung"
+
+msgid "reviewer.article.notifyEditorA"
+msgstr "Die Redakteurin/den Redakteur"
+
+msgid "reviewer.article.enterReviewA"
+msgstr "Bitte klicken Sie auf das Symbol, um Ihr Gutachten zu diesem Konferenzbeitrag einzugeben."
+
+msgid "submission.logType.article"
+msgstr "Konferenzbeitrag"
+
+msgid "user.register.selectContext"
+msgstr "Eine Konferenzbandreihe auswählen, bei der Sie sich registrieren möchten:"
+
+msgid "user.register.noJournals"
+msgstr "Auf dieser Seite gibt es keine Konferenzbandreihen, bei denen Sie sich eintragen könnten."
+
+msgid "user.register.registrationDisabled"
+msgstr "Gegenwärtig nimmt diese Konferenzband keine Registrierung von Benutzer/innen entgegen."
+
+msgid "user.register.readerDescription"
+msgstr "Sie werden per E-Mail über neue Konferenzbände der Konferenzbandreihe informiert."
+
+msgid "user.register.openAccessNotificationDescription"
+msgstr "Sie werden per E-Mail benachrichtigt, wenn ein Konferenzband der Konferenzbandreihe frei zugänglich gemacht wird."
+
+msgid "user.register.authorDescription"
+msgstr "Sie können Konferenzbeiträge bei diesem Konferenzband einreichen."
+
+msgid "user.register.reviewerDescriptionNoInterests"
+msgstr "Sie sind bereit, bei dem Konferenzband eingereichte Konferenzbeiträge im Peer Review zu begutachten."
+
+msgid "user.register.reviewerDescription"
+msgstr "Sie sind bereit, bei der Website eingereichte Konferenzbeiträge im Rahmen des Peer Review zu begutachten."
+
+msgid "search.searchFor"
+msgstr "Konferenzbeitrag durchsuchen nach"
+
+msgid "search.allJournals"
+msgstr "allen Konferenzbände"
+
+msgid "article.nonpdf.title"
+msgstr "Konferenzbeitrag herunterladen"
+
+msgid "current.noCurrentIssue"
+msgstr "Kein aktueller Konferenzband"
+
+msgid "current.noCurrentIssueDesc"
+msgstr "Von dieser Konferenzbandreihe ist kein Konferenzband erschienen."
+
+msgid "archive.browse"
+msgstr "Ältere Konferenzbände durchblättern"
+
+msgid "archive.issueUnavailable"
+msgstr "Konferenzband nicht verfügbar"
+
+msgid "about.aboutContext"
+msgstr "Über den Konferenzband"
+
+msgid "about.history"
+msgstr "Konferenzbandreihen-Geschichte"
+
+msgid "about.submissions"
+msgstr "Konferenzbeitragseinreichung"
+
+msgid "about.onlineSubmissions.registrationRequired"
+msgstr "Um Konferenzbeiträge online einzureichen oder den aktuellen Status eines eingereichten Konferenzbeitrags zu überprüfen, müssen Sie registriert und eingeloggt sein. In einen existierenden Account {$login} oder einen neuen Account {$register}."
+
+msgid "about.onlineSubmissions.submissionActions"
+msgstr "{$newSubmission} oder {$viewSubmissions}."
+
+msgid "about.onlineSubmissions.submitToSection"
+msgstr "Eine neue Konferenzbeitragseinreichung in Rubrik <a href=\{$url}\>{$name}</a> machen."
+
+msgid "about.onlineSubmissions.newSubmission"
+msgstr "Neuen Konferenzbeitrag einreichen"
+
+msgid "about.onlineSubmissions.viewSubmissions"
+msgstr "Konferenzbeiträge in Bearbeitung ansehen"
+
+msgid "about.submissionPreparationChecklist"
+msgstr "Checkliste für Konferenzbeitragseinreichungen"
+
+msgid "about.authorFeesMessage"
+msgstr "Dieser Konferenzband erhebt die folgenden Autor/innen-Gebühren."
+
+msgid "about.delayedOpenAccessDescription2"
+msgstr "Monat(e) nach der Veröffentlichung eines Konferenzbands."
+
+msgid "about.aboutSoftware"
+msgstr "Über Open Journal Systems"
+
+msgid "help.ojsHelp"
+msgstr "Hilfe zu Open Journal Systems"
+
+msgid "payment.type.submission"
+msgstr "Gebühr für das Einreichen eines Konferenzbeitrags"
+
+msgid "payment.type.purchaseArticle"
+msgstr "Konferenzbeitragsgebühr"
+
+msgid "payment.type.purchaseIssue"
+msgstr "Konferenzbandegebühr"
+
+msgid "payment.submission.paySubmission"
+msgstr "Konferenzbeitragseinreichungsgebühr zahlen"
+
+msgid "installer.installApplication"
+msgstr "Open Journal Systems installieren"
+
+msgid "installer.upgradeApplication"
+msgstr "Open Journal Systems upgraden"
+
+msgid "log.review.resubmit"
+msgstr "Konferenzbeitrag {$submissionId} wurde erneut zur Begutachtung eingereicht."
+
+msgid "log.copyedit.copyeditorFile"
+msgstr "Eine Lektoratsversion des Konferenzbeitrags wurde hochgeladen."
+
+msgid "log.editor.metadataModified"
+msgstr "Die Metadaten für den Konferenzbeitrag wurden von {$editorName} verändert."
+
+msgid "log.editor.editorFile"
+msgstr "Eine Redaktionsversion des Konferenzbeitrags wurde hochgeladen."
+
+msgid "log.editor.archived"
+msgstr "Konferenzbeitrag {$submissionId} wurde archiviert."
+
+msgid "log.editor.restored"
+msgstr "Konferenzbeitrag {$submissionId} wurde wieder auf die Liste gesetzt."
+
+msgid "log.proofread.complete"
+msgstr "{$proofreaderName} hat Konferenzbeitrag {$submissionId} auf den Zeitplan gesetzt."
+
+msgid "log.imported"
+msgstr "{$userName} hat Konferenzbeitrag {$submissionId} importiert."
+
+msgid "metadata.pkp.peerReviewed"
+msgstr "Im Peer Review begutachteter Konferenzbeitrag"
+
+msgid "notification.type.submissionSubmitted"
+msgstr "Ein neuer Konferenzbeitrag wurde eingereicht: \{$title}\."
+
+msgid "notification.type.issuePublished"
+msgstr "Eine Konferenzband wurde veröffentlicht."
+
+msgid "notification.type.submissions"
+msgstr "Konferenzbeitragseinreichungsereignisse"
+
+msgid "notification.savedIssueMetadata"
+msgstr "Konferenzbandmetadaten gespeichert."
+
+msgid "user.authorization.noContext"
+msgstr "Es konnte keine Konferenzband gefunden werden, die mit Ihrer Anfrage übereinstimmt."
+
+msgid "user.authorization.sectionAssignment"
+msgstr "Sie versuchen auf einen Konferenzbeitrag zuzugreifen, der nicht Teil Ihrer Rubrik ist."
+
+msgid "user.authorization.invalidIssue"
+msgstr "Ungültigen Konferenzband angefordert!"
+
+msgid "user.authorization.invalidCopyditorSubmission"
+msgstr "Ungültige Lektor/innenfassung oder keine Lektor/innenfassung angefordert!"
+
+msgid "grid.action.createContext"
+msgstr "Neuen Konferenzband anlegen"
+
+msgid "editor.navigation.issues"
+msgstr "Konferenzbände"
+
+msgid "user.profile.form.showOtherContexts"
+msgstr "Bei anderen Konferenzbänden registrieren"
+
+msgid "user.profile.form.hideOtherContexts"
+msgstr "Andere Konferenzbände ausblenden"
+
+msgid "article.view.interstitial"
+msgstr "Bitte wählen Sie eine Konferenzbeitragsdatei zum Download aus."
+
+msgid "search.cli.rebuildIndex.indexing"
+msgstr "Indiziere \{$journalName}\"
+
+msgid "search.cli.rebuildIndex.indexingByJournalNotSupported"
+msgstr "Diese Implementierung der Suche erlaubt keine Neuindizierung pro Konferenzband."
+
+msgid "editor.issues.backIssues"
+msgstr "Frühere Konferenzbände"
+
+msgid "editor.issues.futureIssues"
+msgstr "Zukünftige Konferenzbände"
+
+msgid "catalog.sortBy"
+msgstr "Konferenzbeitragreihenfolge"
+
+msgid "catalog.sortBy.categoryDescription"
+msgstr "Wählen Sie, wie Konferenzbeitrag in dieser Kategorie sortiert sein sollen."

--- a/customLocale/de_DE/locale/de_DE/manager.po
+++ b/customLocale/de_DE/locale/de_DE/manager.po
@@ -1,0 +1,522 @@
+msgid "manager.distribution.copyrightYearBasis.description"
+msgstr "Bitte wählen Sie aus, wie das Standard Copyright Datum für einen Konferenzbeitrag ausgewählt werden soll. Dieser Standard kann von Fall zu Fall überschrieben werden. Praktizieren Sie \publish as you go\, nutzen Sie nicht das Publikationsdatum des Konferenzbands."
+
+msgid "manager.distribution.copyrightYearBasis.issue"
+msgstr "Das Publikationsdatum des Konferenzbands verwenden"
+
+msgid "manager.distribution.copyrightYearBasis.submission"
+msgstr "Das Publikationsdatum des Konferenzbeitrags verwenden"
+
+msgid "manager.distribution.publishingMode.none"
+msgstr "OJS wird nicht verwendet, um die Konferenzbändeinhalte online zu veröffentlichen."
+
+msgid "manager.distribution.publishingMode.openAccess"
+msgstr "Die Konferenzband bietet freien Zugang (Open Access) zu ihren Inhalten."
+
+msgid "manager.distribution.publishingMode.subscription"
+msgstr "Einige oder alle Inhalte des Konferenzbands sind nur für Abonnent/innen zugänglich."
+
+msgid "manager.emails.confirmResetAll"
+msgstr "Sind Sie sicher, dass Sie alle E-Mail-Vorlagen in dieser Konferenzbandreihe zurücksetzen möchten? Sie werden alle Anpassungen verlieren, die Sie vorgenommen haben."
+
+msgid "manager.files.note"
+msgstr "Anmerkung: Der Dateinavigator ermöglicht die unmittelbare Betrachtung und Bearbeitung der mit einer Konferenzband verbundenen Dateien und Verzeichnisse."
+
+msgid "manager.journalManagement"
+msgstr "Konferenzbändeverwaltung"
+
+msgid "manager.language.submissions"
+msgstr "Beiträge"
+
+msgid "manager.language.confirmDefaultSettingsOverwrite"
+msgstr "Dies wird alle Konferenzband-Einstellungen, die Sie für diese Regionaleinstellung gewählt hatten, ersetzen"
+
+msgid "manager.languages.noneAvailable"
+msgstr "Leider ist keine weitere Sprache verfügbar. Setzen Sie sich mit Ihrer Administratorin/Ihrem Administrator in Verbindung, wenn Sie in dem Konferenzband weitere Sprachen verwenden möchten."
+
+msgid "manager.languages.primaryLocaleInstructions"
+msgstr "Dies ist die Standardsprache der Konferenzband-Website."
+
+msgid "manager.payment.generalFeesDescription"
+msgstr "\Institutionelle Mitgliedschaft\ steht im \Über uns\ des Konferenzbands unter \Zur Konferenzband\."
+
+msgid "manager.payment.options.acceptSubscriptionPayments"
+msgstr "Hier werden Abonnementzahlungen aktiviert. Art, Kosten, Dauer und Abonnent/innen werden durch die Abonnementverwaltung verwaltet."
+
+msgid "manager.payment.options.enablePayments"
+msgstr "Klicken Sie hier, um das Zahlungsmodul zu aktivieren. Sie müssen die Zahlungsmodalitäten im Formular unten konfigurieren. Bitte beachten Sie, dass die Benutzer/innen eingeloggt sein müssen, um Zahlungen vornehmen zu können."
+
+msgid "manager.payment.options.onlypdf"
+msgstr "Eingeschränkter Zugriff nur auf die PDF-Versionen von Konferenzbeiträgen"
+
+msgid "manager.payment.options.publicationFee"
+msgstr "Veröffentlichung von Konferenzbeiträgen"
+
+msgid "manager.payment.options.purchaseArticleFee"
+msgstr "Konferenzbeitrag erwerben"
+
+msgid "manager.payment.options.purchaseIssueFee"
+msgstr "Konferenzband erwerben"
+
+msgid "manager.payment.readerFeesDescription"
+msgstr "Die ausgewählten Optionen (zusammen mit der jeweiligen Beschreibung und den Gebühren, die weiter unten bearbeitet werden können) erscheinen im \Über uns\ der Konferenzband unter \Zur Konferenzband\ und an allen Stellen, an denen eine Zahlung erforderlich ist."
+
+msgid "manager.people.allEnrolledUsers"
+msgstr "Bei diesem Konferenzband registrierte Benutzer/innen"
+
+msgid "manager.people.allJournals"
+msgstr "Alle Konferenzbände"
+
+msgid "manager.people.allSiteUsers"
+msgstr "Benutzer/innen der Website für diesen Konferenzband registrieren"
+
+msgid "manager.people.confirmRemove"
+msgstr "Diese/n Benutze/in aus diesem Konferenzband streichen? Die Benutzerin/der Benutzer wird dadurch keine Funktionen mehr in diesem Konferenzband haben."
+
+msgid "manager.people.enrollSyncJournal"
+msgstr "Mit dem Konferenzband"
+
+msgid "manager.people.mergeUsers.from.description"
+msgstr "Wählen Sie eine/n Benutzer/in aus, deren/dessen Daten in einem anderen Konto zusammengeführt werden sollen (wenn jemand z.B. zwei Konten hat). Das zuerst ausgewählte Konto wird gelöscht, seine Beiträge, Aufgaben usw. werden dem zweiten Konto zugeschrieben."
+
+msgid "manager.people.syncUserDescription"
+msgstr "Mit der Synchronisierung werden alle in einem anderen Konferenzband in einer bestimmten Funktion eingeschriebenen Benutzer/innen in diesen Konferenzband mit eben dieser Funktion eingetragen. So können Konferenzbände eine bestimmte Benutzer/innen-Gruppe (z.B. Gutachter/innen) miteinander abgleichen."
+
+msgid "manager.sections.alertDelete"
+msgstr "Bevor diese Rubrik entfernt werden kann, müssen Sie Konferenzbeiträge aus dieser Rubrik in andere Rubriken verschieben."
+
+msgid "manager.section.sectionEditorInstructions"
+msgstr "Fügen Sie dieser Rubrik eine/n Rubrikredakteur/in aus den zur Verfügung stehenden Rubrikredakteur/innen hinzu. Sobald er/sie hinzugefügt worden ist, geben Sie an, ob die/der Rubrikredakteur/in den BEGUTACHTUNGS- (Peer Review) oder den REDAKTIONSPROZESS (Lektorat, Layout und Korrekturlektorat) von Beiträgen zu dieser Rubrik durchführen soll. Rubrikredakteur/innen können Sie anlegen, in dem Sie auf <a href=\{$sectionEditorsUrl}\>Rubrikredakteur/innen</a> unter Funktionen in der Konferenzbandverwaltung klicken."
+
+msgid "manager.sections.hideTocAuthor"
+msgstr "Autor/innennamen zu Beiträgen in dieser Rubrik nicht im Inhaltsverzeichnis aufführen."
+
+msgid "manager.sections.hideTocTitle"
+msgstr "Diese Rubrik nicht im Inhaltsverzeichnis des Konferenzbandes aufführen."
+
+msgid "manager.sections.identifyTypeExamples"
+msgstr "(z.B. \Begutachteter Konferenzbeitrag\, \Nicht begutachteter Review\, \Konferenzbeitrag auf Aufforderung\ usw.)"
+
+msgid "manager.sections.open"
+msgstr "Konferenzbeitragseinreichung möglich"
+
+msgid "manager.sections.submissionIndexing"
+msgstr "Wird nicht in den Index des Konferenzbandes aufgenommen"
+
+msgid "manager.section.submissionsToThisSection"
+msgstr "Eingereichte Beiträge für diese Rubrik"
+
+msgid "manager.setup"
+msgstr "Setup"
+
+msgid "manager.setup.homepageContent"
+msgstr "Inhalte der Konferenzband-Homepage"
+
+msgid "manager.setup.homepageContentDescription"
+msgstr "Die Konferenzband-Homepage besteht standardmäßig aus Navigations-Links. Zusätzliche Inhalte können hinzugefügt werden, indem eine oder alle der folgenden Optionen ausgewählt werden. Sie werden in der angezeigten Reihenfolge auftauchen."
+
+msgid "manager.setup.useStyleSheet"
+msgstr "Style sheet des Konferenzbands"
+
+msgid "manager.setup.contextName"
+msgstr "Name des Konferenzbands"
+
+msgid "manager.setup.pageHeader"
+msgstr "Header der Konferenzband-Homepage"
+
+msgid "manager.setup.addItemtoAboutJournal"
+msgstr "Text einfügen, der unter \Über uns\ erscheinen soll"
+
+msgid "manager.setup.appearInAboutJournal"
+msgstr "(Erscheint unter \Über uns\) "
+
+msgid "manager.setup.competingInterests.requireAuthors"
+msgstr "Verlangen Sie von Autor/innen, die einen Konferenzbeitrag einreichen wollen, zusätzlich eine Erklärung zu möglicherweise bestehenden Interessenkonflikten."
+
+msgid "manager.setup.history"
+msgstr "Konferenzband-Geschichte"
+
+msgid "manager.setup.historyDescription"
+msgstr "Dieser Text erscheint auf der \Über uns\-Seite der Konferenzband und kann genutzt werden, um Änderungen des Titels, in der Besetzung des Beirats und in anderen wesentlichen Belangen der Konferenzbandgeschichte zu beschreiben."
+
+msgid "manager.setup.currentIssue"
+msgstr "Aktuelle Konferenzband"
+
+msgid "manager.setup.details.description"
+msgstr "Name der Konferenzband, ISSN, Kontakte, Unterstützer/innen und Suchmaschinen."
+
+msgid "manager.setup.disableUserRegistration"
+msgstr "Konferenzbändeverwalter/innen registrieren alle Benutzer/innen; Redakteur/innen und Rubrikredakteur/innen können nur Gutachter/innen registrieren."
+
+msgid "manager.setup.disciplineDescription"
+msgstr "Hilfreich im Fall eines fachübergreifenden Konferenzbands oder wenn Autor/innen disziplinübergreifende Themen behandeln."
+
+msgid "manager.setup.disciplineProvideExamples"
+msgstr "Geben Sie Beispiele für die relevanten Fachgebiete des Konferenzbands an"
+
+msgid "manager.setup.displayCurrentIssue"
+msgstr "Fügen Sie das Inhaltsverzeichnis (falls vorhanden) des aktuellen Konferenzbands ein."
+
+msgid "manager.setup.emailSignature.description"
+msgstr "Alle E-Mails, die vom System im Namen der Konferenzbandreihe verschickt werden, tragen die folgende Signatur."
+
+msgid "manager.setup.enableAnnouncements.description"
+msgstr "Sie können die Leser/innen über die Konferenzband betreffende Neuigkeiten und Ereignisse auf der Mitteilungsseite des Konferenzbands informieren."
+
+msgid "manager.setup.enableUserRegistration"
+msgstr "Besucher/innen können einen Benutzeraccount bei der Konferenzbandreihe registrieren."
+
+msgid "manager.setup.focusAndScope.description"
+msgstr "Beschreiben Sie Autor/innen, Leser/innen und Bibliothekar/innen die Bandbreite der Konferenzbeiträge und anderer hier zu veröffentlichenden Werke."
+
+msgid "manager.setup.forAuthorsToIndexTheirWorkDescription"
+msgstr "OJS unterstützt das Protocol for Metadata Harvesting der <a href=\http://www.openarchives.org/\ target=\_blank\>Open Archives Initiative</a>, das den Zugang zu gut katalogisierten Forschungsquellen weltweit eröffnet. Die Autor/innen veröffentlichen Metadaten ihrer Beiträge nach einer ähnlichen Vorlage. Die Konferenzbandverwalterin/der Konferenzbandverwalter sollte die Kategorien für die Indizierung auswählen und den Autor/innen passende Beispiele an die Hand geben, die die Indizierung ihrer Arbeit erleichtern, wobei die Begriffe durch Semikolon getrennt werden (z.B. Begriff1; Begriff2). Die Einträge sollten als Beispiele (mit \z.B.\ oder \zum Beispiel\) gekennzeichnet sein."
+
+msgid "manager.setup.form.journalInitialsRequired"
+msgstr "Das Kürzel des Konferenzbandes ist erforderlich."
+
+msgid "manager.setup.form.journalTitleRequired"
+msgstr "Der Titel der Konferenzbandes ist erforderlich."
+
+msgid "manager.setup.form.numReviewersPerSubmission"
+msgstr "Die Zahl der Gutachter/innen pro Konferenzbeitrag wird benötigt."
+
+msgid "manager.setup.guidingSubmissions"
+msgstr "3. Schritt: Konferenzbeitragseinreichung"
+
+msgid "manager.setup.identity"
+msgstr "Konferenzbandidentität"
+
+msgid "manager.setup.includeCreativeCommons"
+msgstr "Für Konferenzbände, die unmittelbaren oder verzögerten Open Access liefern, allen veröffentlichten Werken zu gegebener Zeit eine Creative-Commons-Lizenz hinzufügen."
+
+msgid "manager.setup.information.description"
+msgstr "Kurzbeschreibungen der Konferenzband für Bibliothekar/innen, potentielle Autor/innen und Leser/innen finden sich unter \Informationen\ in der Seitenleiste."
+
+msgid "manager.setup.initialIssue"
+msgstr "Initialer Konferenzband"
+
+msgid "manager.setup.initialIssueDescription"
+msgstr "Geben Sie dem Initialen Konferenzband (je nach gewähltem Format) eine eindeutige Bezeichnung:"
+
+msgid "manager.setup.itemsPerPage.description"
+msgstr "Begrenzen Sie die Anzahl an Objekten (z.B. Konferenzbeitragseinreichungen, Nutzer oder Zuweisungen durch die Redaktion), die in einer Liste angezeigt werden sollen, bevor weitere auf einer Folgeseite angezeigt werden."
+
+msgid "manager.setup.journalAbbreviation"
+msgstr "Abkürzung des Konferenzbandnamens"
+
+msgid "manager.setup.journalArchiving"
+msgstr "Archivierung des Konferenzbands"
+
+msgid "manager.setup.contextSummary"
+msgstr "Zusammenfassung des Konferenzbands"
+
+msgid "manager.setup.contextAbout"
+msgstr "Über uns"
+
+msgid "manager.setup.contextAbout.description"
+msgstr "Nehmen Sie alle Informationen über Ihren Konferenzband mit auf, die von Interesse für Leser/innen, Autor/innen oder Gutachter/innen sein könnten. Hierzu könnten Ihre Open-Access-Policy, das Konzept Ihres Konferenzbands, Copyright-Angaben, Informationen über Sponsoren, die Geschichte des Konferenzbands, Angaben zum Datenschutz und die Beteiligung an LOCKSS- oder CLOCKSS-Archivierungssystemen gehören."
+
+msgid "manager.setup.journalHomepageContent"
+msgstr "Inhalt der Eingangsseite des Konferenzbands"
+
+msgid "manager.setup.journalHomepageContentDescription"
+msgstr "Standardmäßig besteht die Eingangsseite nur aus Navigationslinks. Zusätzlicher Inhalt kann mit einer der folgenden Optionen hinzugefügt werden. Er erscheint in der Reihenfolge der Optionen. Bitte beachten Sie, dass der aktuelle Konferenzband der Konferenzbandreihe immer über den \Aktuelle Konferenzband\-Link in der Navigationsleiste zu erreichen ist."
+
+msgid "manager.setup.journalHomepageHeader"
+msgstr "Kopfzeile der Startseite"
+
+msgid "manager.setup.journalHomepageHeader.altText"
+msgstr "Kopfzeile der Startseite des Konferenzband"
+
+msgid "manager.setup.journalHomepageHeaderDescription"
+msgstr "Grafische Versionen der Konferenzbandtitel und -logo (als .gif-, .jpg- oder .png-Dateien) können für die Startseite hochgeladen werden (ansonsten erscheint eine Textversion)."
+
+msgid "manager.setup.contextInitials"
+msgstr "Kürzel des Konferenzbands"
+
+msgid "manager.setup.journalLayout"
+msgstr "Konferenzbandlayout"
+
+msgid "manager.setup.journalLayoutDescription"
+msgstr "Entscheiden Sie sich für eine Designvorlage für Ihren Konferenzband und wählen Sie hier mögliche Layout-Bestandteile aus. Sie können auch ein Konferenzband-Style Sheet hochladen, mit dessen Hilfe Sie die durch die System- und Themen-Style Sheets vorgegebenen Einstellungen ersetzen können."
+
+msgid "manager.setup.journalLogo"
+msgstr "Logo des Konferenzbands"
+
+msgid "manager.setup.journalLogo.altText"
+msgstr "Logo des Konferenzbands"
+
+msgid "manager.setup.journalPageFooter"
+msgstr "Fußzeile des Konferenzbands"
+
+msgid "manager.setup.journalPageFooterDescription"
+msgstr "Dies ist die Fußzeile Ihres Konferenzbands. Sollten Sie sie ändern oder aktualisieren wollen, kopieren Sie den neuen HTML-Text in das nachstehende Textfeld. Beispiele könnten eine zusätzliche Navigationszeile oder ein Zähler sein. Diese Fußzeile wird auf allen Seiten erscheinen."
+
+msgid "manager.setup.journalPolicies"
+msgstr "2. Schritt: Konferenzbandrichtlinien und Publikationsprozess"
+
+msgid "manager.setup.journalSetup"
+msgstr "Einrichten des Konferenzbands"
+
+msgid "manager.setup.journalSetupUpdated"
+msgstr "Die Konfiguration Ihres Konferenzbands wurde aktualisiert."
+
+msgid "manager.setup.journalStyleSheetInvalid"
+msgstr "Das Format des Konferenzband-Style Sheets ist ungültig. Das gültige Format ist .css."
+
+msgid "manager.setup.journalTheme"
+msgstr "Konferenzband-Designvorlage"
+
+msgid "manager.setup.journalThumbnail"
+msgstr "Vorschaubild des Konferenzbands"
+
+msgid "manager.setup.journalThumbnail.description"
+msgstr "Ein kleines Logo oder Symbol Ihres Konferenzbands, das in der Liste der Konferenzbände angezeigt werden kann."
+
+msgid "manager.setup.contextTitle"
+msgstr "Titel der Konferenzband"
+
+msgid "manager.setup.keyInfo.description"
+msgstr "Geben Sie eine kurze Beschreibung Ihres Konferenzbands ein und benennen Sie Redakteure, Direktoren und andere Mitglieder Ihres Redaktionsteams."
+
+msgid "manager.setup.plnDescription"
+msgstr "Das PKP Preservation Network (PN) stellt freie Archivierungsdienste für jede OJS-Konferenzbandreihe bereit, die einige grundsätzliche Kriterien erfüllt."
+
+msgid "manager.setup.plnPluginNotInstalled"
+msgstr "Das PKP Preservation Network (PN) stellt freie Archivierungsdienste für jede OJS-Konferenzbandreihe bereit, die einige grundsätzliche Kriterien erfüllt. Das PKP-PN-Plugin für OJS 3 wird momentan entwickelt und wird bald in der Plugin-Gallerie verfügbar sein."
+
+msgid "manager.setup.lockssEnable"
+msgstr "Aktivieren Sie LOCKSS und speichern und verteilen Sie den Inhalt des Konferenzbands bei den an LOCKSS teilnehmenden Bibliotheken über ein <a href=\{$lockssUrl}\ target=\_blank\>LOCKSS-Manifest</a>."
+
+msgid "manager.setup.lockssLicenseDescription"
+msgstr "Eine LOCKSS-Lizenz wird in \Über uns\ unter Archivierung erscheinen: <a href=\http://www.lockss.org/community/publishers-titles-gln/\ target=\_blank\>LOCKSS-Lizenz</a>"
+
+msgid "manager.setup.lockssRegister"
+msgstr "Identifizieren Sie 6 bis 10 Bibliotheken, die die Konferenzband registrieren und archivieren sollen. Wenden Sie sich zum Beispiel an Einrichtungen, in denen Mitglieder der Redaktion oder des Beirats arbeiten und/oder Einrichtungen, die bereits an LOCKSS beteiligt sind. Siehe <a href=\http://www.lockss.org/community/\ target=\_blank\>the LOCKSS community</a>."
+
+msgid "manager.setup.clockssEnable"
+msgstr "Aktivieren Sie CLOCKSS und speichern und verteilen Sie den Inhalt des Konferenzbands bei den an CLOCKSS teilnehmenden Bibliotheken über ein <a href=\{$clockssUrl}\ target=\_blank\>CLOCKSS-Manifest</a>."
+
+msgid "manager.setup.clockssLicenseDescription"
+msgstr "Eine CLOCKSS-Lizenz wird in \Über uns\ unter Archivierung erscheinen: <a href=\http://clockss.org/\ target=\_blank\>CLOCKSS-Lizenz</a>"
+
+msgid "manager.setup.look.description"
+msgstr "Titel der Startseite, Inhalt, Kopfzeile des Konferenzbands, Fußzeile, Navigationsleiste und Style Sheet."
+
+msgid "manager.setup.managingTheJournal"
+msgstr "4. Schritt: Den Konferenzband verwalten"
+
+msgid "manager.setup.navItemIsLiteral"
+msgstr "Die Seitenbenennung besteht aus einer Buchstabenkette (z.B. \Einrichtung des Konferenzbands\) und nicht aus einem Lokalisierungsschlüssel (z.B. \manager.setup\)"
+
+msgid "manager.setup.notifications.submissionAckDisabled"
+msgstr "<strong>Anmerkung:</strong> Die Funktion \Eingangsbestätigung per E-Mail\ ist deaktiviert. Um diese Funktion zu nutzen, aktivieren Sie \SUBMISSION_ACK email\ in E-Mails."
+
+msgid "manager.setup.proofingInstructionsDescription"
+msgstr "Die Anweisungen für das Korrekturlektorat werden den Korrekturlektor/innen, Autor/innen, Layouter/innen und Rubrikredakteur/innen während der redaktionellen Bearbeitung des Konferenzbeitrags übermittelt. Nachstehend finden Sie einen Standardsatz von Anweisungen in HTML-Format, die jederzeit von der Konferenzbandverwaltung geändert werden können (in HTML oder einfachem Text)."
+
+msgid "manager.setup.publicationScheduleDescription"
+msgstr "Die Beiträge des Konferenzbands können zusammen veröffentlicht werden, als Teil einer Konferenzband mit eigenem Inhaltsverzeichnis. Es können auch einzelne fertige Konferenzbeitrag durch Anfügen an das Inhaltsverzeichnis der \aktuellen Konferenzband\ veröffentlicht werden. Erläutern Sie den Leser/innen unter \Über uns\ das Veröffentlichungssystem und die vorgesehene Erscheinungsfrequenz der Konferenzband."
+
+msgid "manager.setup.publicIdentifier"
+msgstr "Kennung des Inhalts des Konferenzbands"
+
+msgid "manager.setup.restrictSiteAccess"
+msgstr "Benutzer/innen müssen registriert und angemeldet sein, um die Konferenzbandseite aufrufen zu können."
+
+msgid "manager.setup.reviewOptions.restrictReviewerFileAccess.description"
+msgstr "Erst wenn sie der Übernahme der Begutachtung zugestimmt haben, erhalten Gutachter/innen Zugriff auf die jeweilige Konferenzbeitragsdatei."
+
+msgid "manager.setup.searchDescription.description"
+msgstr "Geben Sie eine kurze Beschreibung (50-300 Zeichen) des Konferenzbands an, die Suchmaschinen anzeigen können, wenn der Konferenzband in den Suchergebnissen aufgelistet wird."
+
+msgid "manager.setup.sectionsDefaultSectionDescription"
+msgstr "(Falls keine Rubrik angegeben wird, werden die Beiträge standardmäßig für die Rubrik Konferenzbeitrag eingereicht.)"
+
+msgid "manager.setup.sectionsDescription"
+msgstr "Gehen Sie zur Rubrikverwaltung, um Konferenzbandrubriken einzurichten oder zu verändern (z.B. Konferenzbeitrag, Rezensionen usw.).<br /><br /> Wenn Beiträge eingereicht werden, schlagen die Autor/innen eine Rubrik vor."
+
+msgid "manager.setup.selectEditorDescription"
+msgstr "Redakteur/in, die/der den Konferenzbeitrag betreut."
+
+msgid "manager.setup.selectSectionDescription"
+msgstr "Die Rubrik des Konferenzbands, für die der Konferenzbeitrag in Frage kommt."
+
+msgid "manager.setup.siteAccess.viewContent"
+msgstr "Konferenzbeitragsinhalt ansehen"
+
+msgid "manager.setup.stepsToJournalSite"
+msgstr "Fünf Schritte zu einem Konferenzband"
+
+msgid "manager.setup.submissionGuidelines"
+msgstr "Richtlinien für die Konferenzbeitragseinreichung"
+
+msgid "manager.setup.submissionPreparationChecklist"
+msgstr "Checkliste zur Vorbereitung der Einreichung des Konferenzbandbeitrags"
+
+msgid "manager.setup.submissionPreparationChecklistDescription"
+msgstr "Bei der Einreichung eines Konferenzbeitrags zur Konferenzbandreihe werden die Autoren zunächst gebeten, jedes Element in der Checkliste zur Vorbereitung der Einreichung als abgeschlossen zu markieren, bevor sie fortfahren. Die Checkliste findet sich auch in den Autorenrichtlinien, unter „Über die Konferenzbandreihe“. Die Liste kann unten bearbeitet werden, aber alle Elemente auf der Liste müssen mit einem Häkchen versehen sein, bevor die Autoren mit ihrer Konferenzbandbeitragseinreichung fortfahren können."
+
+msgid "manager.setup.submissions"
+msgstr "Konferenzbeitragseinreichung"
+
+msgid "manager.setup.disableSubmissions.description"
+msgstr "Verhindern Sie, dass Nutzer/innen neue Konferenzbeitrag für diese Konferenzband einreichen. Auf der Seite <a href=\{$url}\>journal sections</a> können Konferenzbeitragseinreichungen für individuelle Rubriken deaktiviert werden."
+
+msgid "manager.setup.disableSubmissions.notAccepting"
+msgstr "Dieser Konferenzband nimmt derzeit keine Konferenzbeitragseinreichungen entgegen. Gehen Sie zu Workflow-Einstellungen, um Konferenzbeitragseinreichungen zu aktivieren."
+
+msgid "manager.setup.uniqueIdentifierDescription"
+msgstr "Konferenzbeiträge und Konferenzbände können mit einer Identifikationsnummer oder einer Zeichenkette gekennzeichnet werden, wobei ein System, z.B. das DOI (Digital Object Identifier)-System, verwendet werden sollte."
+
+msgid "manager.setup.useEditorialReviewBoard"
+msgstr "Der Konferenzband hat eine Redaktion bzw. ein Herausgeber/innengremium."
+
+msgid "manager.statistics.statistics"
+msgstr "Konferenzbandstatistik"
+
+msgid "manager.statistics.statistics.articleViews"
+msgstr "Konferenzbeitrag angesehen (nur für Autor/innen)"
+
+msgid "manager.statistics.statistics.description"
+msgstr "OJS berechnet folgende Statistiken für jede Konferenzbandreihe: \Tage bis zur Begutachtung\ wird vom Konferenzbeitragseingang (oder dem Eingang der zu begutachtenden Version) bis zur ersten Redaktionsentscheidung berechnet, während die \Tage bis zur Veröffentlichung\ der angenommenen Beiträge vom Hochladen des Originals bis zur Veröffentlichung berechnet werden."
+
+msgid "manager.statistics.statistics.makePublic"
+msgstr "Mitteilungen, die den Leser/innen in \Über uns\ vermittelt werden."
+
+msgid "manager.statistics.statistics.note"
+msgstr "Anmerkung: Die Prozentsätze der Gutachter/innenempfehlungen summieren sich nicht notwendigerweise auf 100 %, weil erneut eingereichte Beiträge entweder angenommen, abgelehnt oder noch in Bearbeitung sein können."
+
+msgid "manager.statistics.statistics.numIssues"
+msgstr "Erschienene Konferenzbände"
+
+msgid "manager.statistics.statistics.numSubmissions"
+msgstr "Gesamtzahl der Konferenzbeiträge"
+
+msgid "manager.statistics.statistics.selectSections"
+msgstr "Wählen Sie die Rubriken für die Berechnung der Peer-Review-Statistiken des Konferenzbands aus."
+
+msgid "manager.statistics.reports.defaultReport.articleDownloads"
+msgstr "Downloads von Konferenzbeitragsdateien"
+
+msgid "manager.statistics.reports.defaultReport.articleAbstract"
+msgstr "Aufrufe der Abstractseiten von Konferenzbeiträgen"
+
+msgid "manager.statistics.reports.defaultReport.articleAbstractAndDownloads"
+msgstr "Abstractseiten und Downloads"
+
+msgid "manager.statistics.reports.defaultReport.journalIndexPageViews"
+msgstr "Startseiten-Aufrufe"
+
+msgid "manager.statistics.reports.defaultReport.issuePageViews"
+msgstr "Aufrufe des Inhaltverzeichnis des Konferenzbands"
+
+msgid "manager.statistics.reports.filters.byContext.description"
+msgstr "Ergebnisse nach Kontext eingrenzen (Konferenzbände und/oder Konferenzbandbeiträge)."
+
+msgid "manager.statistics.reports.filters.byObject.description"
+msgstr "Ergebnisse nach Objekttyp (Konferenzbandreihe, Konferenzband, Konferenzbandbeiträge, Dateitypen) und/oder nach einer oder mehreren Objekt-IDs eingrenzen."
+
+msgid "manager.subscriptionPolicies.expiryRemindersDescription"
+msgstr "Automatische E-Mails zur Erinnerung (verfügbar unter den Standard-E-Mails des OJS) können den Abonnent/innen sowohl vor als auch nach dem Ablauf des Abonnements zugehen."
+
+msgid "manager.subscriptionPolicies.openAccessNotificationDescription"
+msgstr "Eingetragene Benutzer/innen können sich das Inhaltsverzeichnis eines Konferenzbands per E-Mail zuschicken lassen, sobald dieser frei zugänglich ist."
+
+msgid "manager.subscriptionPolicies.onlinePaymentNotificationsDescription"
+msgstr "An die Abonnementverwalter/innen können automatische Mailbenachrichtigungen (verfügbar für Konferenzbandeverwalter/innen in den OJS-E-Mail-Vorlagen) verschickt werden bei Vervollständigung der Online-Zahlung von Abonnements."
+
+msgid "manager.subscriptionPolicies.onlinePaymentDisabled"
+msgstr "<strong>Hinweis:</strong> Um diese Optionen zu aktivieren, muss die Konferenzbanverwalterin/der Konferenzbandverwalter unter Leser/innengebühren die Onlinezahlungsmodule aktivieren, incl. der Onlinezahlungen für Abonnements."
+
+msgid "manager.subscriptionPolicies.openAccessOptions"
+msgstr "Open-Access-Optionen für Abonnement-Konferenzbände"
+
+msgid "manager.subscriptionPolicies.openAccessOptionsDescription"
+msgstr "Konferenzbände mit Abonnement können \verzögerten Open Access\ und/oder \Selbstarchivierung durch die/den Autor/in\ anbieten und damit die Leser/innenschaft vergrößern und die Häufigkeit, in der Beiträge zitiert werden, heraufsetzen."
+
+msgid "manager.subscriptions.form.subscriptionContactRequired"
+msgstr "Um der Benutzerin/dem Benutzer eine Benachrichtigung per E-Mail zuschicken zu können, müssen Name und E-Mail-Adresse der Abonnementverwaltung bei der Einrichtung des Konferenzbands festgelegt werden."
+
+msgid "manager.subscriptions.form.subscriptionExists"
+msgstr "Diese/r Benutzer/in hat diesen Konferenzband bereits abonniert."
+
+msgid "manager.subscriptions.selectSubscriber.desc"
+msgstr "Die Konferenzbandverwalter/innen, Redakteur/innen, Rubrikredakteur/innen, Layouter/innen, Lektor/innen und Korrekturlektor/innen haben automatisch die Zugangsprivilegien von Abonnent/innen."
+
+msgid "manager.setup.categories.description"
+msgstr "Wählen Sie die passendsten Kategorien aus der oben angezeigten Menge. Leser/innen können die gesamte Konferenzbandreihe dann nach Kategorien durchsehen."
+
+msgid "manager.setup.section.description"
+msgstr "Konferenzbeiträge innerhalb veröffentlichter Konferenzbände einer Konferenzbandreihe sind in Rubriken organisiert, normalerweise anhand eines Themas oder Inhaltstyps (z.B. Überblicksartikel, Forschung etc.)."
+
+msgid "settings.roles.gridDescription"
+msgstr "Rollen sind Nutzergruppen des Konferenzbands, die Zugang zu verschiedenen Rechteleveln und damit verbundenen Workflows erhalten. Es gibt fünf verschiedene Rechtelevel: Konferenzbandverwalter/innen haben kompletten Zugriff auf die Konferenzband (alle Inhalte und Einstellungen); Rubrikredakteur/innen haben kompletten Zugriff auf alle ihnen zugewiesenen Konferenzbeitragseinreichungen; Konferenzbandassistent/innen haben begrenzten Zugriff auf alle Konferenzbeitragseinreichungen, die ihnen explizit durch eine/n Redakteur/in zugewiesen worden sind. Gutachter/innen können die ihnen zugewiesenen Beiträge sehen und begutachten, und Autor/innen können im begrenzten Umfang Informationen über ihre eigenen Konferenzbeitragseinreichungen sehen und bearbeiten. Zusätzlich gibt es fünf verschiedene Phasen, auf die Rollen Zugriff erhalten können: Konferenzbeitragseinreichung, Interne Begutachtung, Externe Begutachtung, Lektorat und Produktion."
+
+msgid "manager.setup.copyrightYearBasis"
+msgstr "Basiere das Copyright-Jahr eines neuen Konferenzbeitrags auf"
+
+msgid "manager.setup.copyrightYearBasis.article"
+msgstr "Konferenzbeitrag: das Standardjahr wird aus dem Veröffentlichungsjahr des Konferenzbeitrags abgeleitet, wie bei \publish-as-you-go\."
+
+msgid "manager.setup.copyrightYearBasis.issue"
+msgstr "Konferenzband: das Standardjahr wird aus dem Veröffentlichungsdatum des Konferenzbands abgeleitet."
+
+msgid "manager.setup.resetPermissions"
+msgstr "Konferenzbeitragsrechte zurücksetzen"
+
+msgid "manager.setup.resetPermissions.confirm"
+msgstr "Sind Sie sicher, dass Sie die Rechte, die bisher den Konferenzbeiträgen zugewiesen sind, zurücksetzen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+
+msgid "manager.setup.resetPermissions.description"
+msgstr "Entfernen Sie die Urheberrechtserklärung und die Lizenzinformationen für jeden veröffentlichten Konferenzbeitrag, um sie auf die aktuellen Standardeinstellungen des Konferenzbands zurückzusetzen. Dadurch werden alle früheren Copyright- und Lizenzinformationen, die den Konferenzbeiträgen beigefügt waren, dauerhaft entfernt. In einigen Fällen ist es Ihnen gesetzlich nicht gestattet, Werke, die unter einer anderen Lizenz veröffentlicht wurden, neu zu lizenzieren. Bitte seien Sie vorsichtig bei der Verwendung dieses Tools und konsultieren Sie juristischen Beistand, wenn Sie sich nicht sicher sind, welche Rechte Sie an den in Ihres Konferenzbands veröffentlichten Konferenzbeiträgen haben."
+
+msgid "manager.setup.resetPermissions.success"
+msgstr "Konferenzbeitragsrechte wurden erfolgreich zurückgesetzt."
+
+msgid "grid.genres.title"
+msgstr "Konferenzbeitragsbestandteile"
+
+msgid "grid.genres.description"
+msgstr "Diese Bestandteile werden genutzt, um Dateien zu benennen. Sie werden in einem Pull-Down-Menü beim Hochladen von Dateien angezeigt. Die Genres, die mit ## markiert sind, ermöglichen es der Nutzerin/dem Nutzer, die Datei entweder mit der kompletten Konferenzbeitragseinreichung 99Z oder einem bestimmten Bestandteil, identifiziert anhand der Nummer (z.B. 02), zu verknüpfen."
+
+msgid "plugins.importexport.common.export.articles"
+msgstr "Konferenzbeitrag"
+
+msgid "plugins.importexport.common.export.issues"
+msgstr "Konferenzbände"
+
+msgid "plugins.importexport.common.filter.issue"
+msgstr "Jeder Konferenzband"
+
+msgid "plugins.importexport.common.senderTask.warning.noDOIprefix"
+msgstr "DOI-Präfix fehlt für den Konferenzband mit dem Pfad {$path}."
+
+msgid "plugins.importexport.common.error.unknownJournal"
+msgstr "Der angegebene Pfad der Konferenzbandreihe, {$journalPath}, existiert nicht."
+
+msgid "plugins.importexport.common.error.import.issueGalleyFileMissing"
+msgstr "Eine Fahne konnte nicht importiert werden, die Datei fehlt."
+
+msgid "plugins.importexport.common.error.issueGalleyFileMissing"
+msgstr "Die Konferenzbandfahne {$id} konnte nicht exportiert werden, die Datei wurde nicht unter dem Pfad \{$path}\ gefunden."
+
+msgid "plugins.importexport.common.error.issueCoverImageMissing"
+msgstr "Das Titelbild dea Konferenzbands {$id} wurde nicht exportiert, die Datei wurde nicht unter dem Pfad \{$path}\ gefunden."
+
+msgid "manager.setup.notifications.copyPrimaryContact"
+msgstr "Eine Kopie an den in den Einstellungen der Konferenzband festgelegten Hauptkontakt senden."
+
+msgid "stats.publicationStats"
+msgstr "Konferenzbeitragstatistik"
+
+msgid "stats.publications.details"
+msgstr "Konferenzbeitragdetails"
+
+msgid "stats.publications.none"
+msgstr "Es wurden keine Konferenzbeiträge mit Nutzungsstatistiken gefunden, die diesen Parametern entsprechen."
+
+msgid "stats.publications.countOfTotal"
+msgstr "{$count} von {$total} Konferenzbeiträgen"
+

--- a/customLocale/de_DE/locale/de_DE/submission.po
+++ b/customLocale/de_DE/locale/de_DE/submission.po
@@ -1,0 +1,99 @@
+msgid "submission.submit.title"
+msgstr "Konferenzbeitrag einreichen"
+
+msgid "submission.submit.userGroupDescription"
+msgstr "Wählen Sie die Rolle aus, in der Sie diesen Konferenzbandbeitrag einreichen."
+
+msgid "submission.upload.selectComponent"
+msgstr "Konferenzbeitrag-Bestandteil auswählen"
+
+msgid "submission.title"
+msgstr "Konferenzbeitragstitel"
+
+msgid "submission.submit.newSubmissionMultiple"
+msgstr "Eine neue Konferenzbeitragseinreichung beginnen in"
+
+msgid "submission.submit.newSubmissionSingle"
+msgstr "Neue Konferenzbeitragseinreichung"
+
+msgid "grid.action.workflow"
+msgstr "Konferenzbeitragseinreichungsworkflow"
+
+msgid "submission.submit.noContext"
+msgstr "Der Konferenzband für diese Konferenzbeitragseinreichung konnte nicht gefunden werden."
+
+msgid "grid.action.galleyInIssueEntry"
+msgstr "Fahne in dem Konferenzband angezeigt"
+
+msgid "grid.action.issueEntry"
+msgstr "Die Metadaten dieses Konferenzbeitrages ansehen"
+
+msgid "submission.event.articleGalleyMadeAvailable"
+msgstr "Die Konferenzbeitragfahne \{$galleyFormatName}\ wird verfügbar gemacht."
+
+msgid "submission.event.articleGalleyMadeUnavailable"
+msgstr "Die Konferenzbeitragfahne \{$galleyFormatName}\ wird nicht mehr verfügbar sein."
+
+msgid "submission.event.publicIdentifiers"
+msgstr "Die Identifier des Konferenzbeitrages wurden aktualisiert."
+
+msgid "submission.confirmSubmit"
+msgstr "Sind Sie sicher, dass Sie diesen Beitrag zum Konferenzband für die Konferenzbandreihe einreichen möchten?"
+
+msgid "submission.event.issueMetadataUpdated"
+msgstr "Die Metadaten des Konferenbandes dieser Konferenzbeitragseinreichung wurden aktualisiert."
+
+msgid "submission.upload.fileContents"
+msgstr "Konferenzbeitrag-Bestandteil"
+
+msgid "submission.submit.form.localeRequired"
+msgstr "Bitte wählen Sie eine Sprache für die Einreichung Ihres Konferenzbandbeitrags aus."
+
+msgid "submission.submit.submissionChecklist"
+msgstr "Konferenzbeitragseinreichungs-Checkliste"
+
+msgid "submission.submit.form.titleRequired"
+msgstr "Bitte geben Sie den Titel Ihres Konferenzbeitrags an."
+
+msgid "submission.submit.form.abstractRequired"
+msgstr "Bitte geben Sie das Abstract Ihres Konferenzbeitrags an."
+
+msgid "publication.assignToissue"
+msgstr "Einem Konferenzband zuordnen"
+
+msgid "publication.changeIssue"
+msgstr "Konferenzband ändern"
+
+msgid "publication.invalidIssue"
+msgstr "Der Konferenzband für diese Veröffentlichung konnte nicht gefunden werden."
+
+msgid "publication.publishedIn"
+msgstr "Veröffentlicht in <a href=\{$issueUrl}\>{$issueName}</a>."
+
+msgid "publication.scheduledIn"
+msgstr "Vorgesehen zur Veröffentlichung in <a href=\{$issueUrl}\>{$issueName}</a>."
+
+msgid "publication.unscheduledIn"
+msgstr "Dieser Konferenzbeitrag wurde nicht für die Veröffentlichung in einem Konferenzband vorgesehen."
+
+msgid "publication.selectIssue"
+msgstr "Wählen Sie einen Konferenzband zur Planung der Veröffentlichung"
+
+msgid "publication.event.published"
+msgstr "Der Konferenzbeitrag wurde veröffentlicht."
+
+msgid "publication.event.scheduled"
+msgstr "Der Konferenzbeitrag wurde zur Veröffentlichung vorgesehen."
+
+msgid "publication.event.unpublished"
+msgstr "Der Konferenzbeitrag wurde zurückgezogen."
+
+msgid "publication.invalidSubmission"
+msgstr "Die Konferenzbeitragseinreichung für diese Veröffentlichung konnte nicht gefunden werden."
+
+msgid "publication.required.declined"
+msgstr "Ein abgelehnter Konferenzbeitrag kann nicht veröffentlicht werden."
+
+msgid "submission.copyrightOther.description"
+msgstr "Die Rechte am veröffentlichten Konferenzbeitrag folgender Gruppe zuordnen."
+

--- a/customLocale/en_US/locale/en_US/emails.po
+++ b/customLocale/en_US/locale/en_US/emails.po
@@ -123,7 +123,7 @@ msgid "emails.emailLink.subject"
 msgstr "Conference Proceedings Submission of Possible Interest"
 
 msgid "emails.emailLink.body"
-msgstr "Thought you might be interested in seeing &quot;{$Conference Proceedings  SubmissionTitle}&quot; by {$authorName} published in Vol {$volume}, No {$number} ({$year}) of {$contextName} at &quot;{$Conference Proceedings SubmissionUrl}&quot;."
+msgstr "Thought you might be interested in seeing &quot; {$submissionTitle}&quot; by {$authorName} published in Vol {$volume}, No {$number} ({$year}) of {$contextName} at &quot; {$submissionUrl}&quot;."
 
 msgid "emails.emailLink.description"
 msgstr "This email template provides a registered reader with the opportunity to send information about an Conference Proceedings Submission to somebody who may be interested. It is available via the Reading Tools and must be enabled by the Conference Proceedings Series Manager in the Reading Tools Administration page."

--- a/customLocale/en_US/locale/en_US/manager.po
+++ b/customLocale/en_US/locale/en_US/manager.po
@@ -495,7 +495,7 @@ msgid "plugins.importexport.common.senderTask.warning.noDOIprefix"
 msgstr "DOI prefix is missing for the Conference Proceedings Series with the path {$path}."
 
 msgid "plugins.importexport.common.error.unknownJournal"
-msgstr "The specified journal path, \"{$Conference Proceedings SeriesPath}\", does not exist."
+msgstr "The specified Conference Proceedings Series path, \"{$journalPath}\", does not exist."
 
 msgid "plugins.importexport.common.error.import.issueGalleyFileMissing"
 msgstr "An Conference Proceedings Volume galley could not be imported, its file is missing."

--- a/customLocale/en_US/locale/en_US/submission.po
+++ b/customLocale/en_US/locale/en_US/submission.po
@@ -69,10 +69,10 @@ msgid "publication.invalidIssue"
 msgstr "The Conference Proceedings Volume for this publication could not be found."
 
 msgid "publication.publishedIn"
-msgstr "Published in <a href=\"{$issueUrl}\">{$Conference Proceedings VolumeName}</a>."
+msgstr "Published in <a href=\"{$issueUrl}\">{issueTitle}</a>."
 
 msgid "publication.scheduledIn"
-msgstr "Scheduled for publication in <a href=\"{$issueUrl}\">{$Conference Proceedings VolumeName}</a>."
+msgstr "Scheduled for publication in <a href=\"{$issueUrl}\">{$journalTitle}</a>."
 
 msgid "publication.unscheduledIn"
 msgstr "This has not been scheduled for publication in an Conference Proceedings Volume."


### PR DESCRIPTION
Hier nun Part 2 mit den restlichen Anpassungen. 
